### PR TITLE
feat: implement support widget with Express server (#7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "punchlist.config.example.json"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/build-widget.mjs",
+    "build:widget": "node scripts/build-widget.mjs",
     "dev": "tsc --watch",
     "cli": "node bin/punchlist.mjs",
     "start": "node bin/punchlist.mjs",
@@ -51,10 +52,13 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "esbuild": "^0.27.4",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
+    "happy-dom": "^20.8.4",
     "prettier": "^3.8.1",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.57.1",
@@ -62,6 +66,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.8.0",
+    "express": "^5.2.1",
     "zod": "^4.3.6"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -21,18 +24,27 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@20.19.37))
+        version: 3.2.4(vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4))
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.4
       eslint:
         specifier: ^10.0.3
         version: 10.0.3
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.0.3)
+      happy-dom:
+        specifier: ^20.8.4
+        version: 20.8.4
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -44,7 +56,7 @@ importers:
         version: 8.57.1(eslint@10.0.3)(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.37)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)
 
 packages:
 
@@ -437,8 +449,14 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -449,11 +467,38 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -552,6 +597,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -608,6 +657,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -618,9 +671,21 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -639,6 +704,22 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -668,12 +749,23 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -681,16 +773,39 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -747,6 +862,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -754,6 +873,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -780,6 +903,10 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -795,6 +922,14 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -802,6 +937,17 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -815,12 +961,36 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  happy-dom@20.8.4:
+    resolution: {integrity: sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ==}
+    engines: {node: '>=20.0.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -843,6 +1013,10 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -854,6 +1028,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -919,6 +1096,26 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -955,9 +1152,21 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -977,6 +1186,10 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -988,6 +1201,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1022,12 +1238,28 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1042,13 +1274,31 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1057,6 +1307,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1077,6 +1343,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1144,6 +1414,10 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -1156,6 +1430,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript-eslint@8.57.1:
     resolution: {integrity: sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==}
@@ -1172,11 +1450,19 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1251,6 +1537,10 @@ packages:
       jsdom:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1275,6 +1565,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1535,10 +1837,19 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.37
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.37
 
   '@types/deep-eql@4.0.2': {}
 
@@ -1546,11 +1857,45 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 20.19.37
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.37
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.37
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.37
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)':
     dependencies:
@@ -1643,7 +1988,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.37))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1658,7 +2003,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.37)
+      vitest: 3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -1703,6 +2048,11 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -1756,6 +2106,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -1769,7 +2133,19 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@5.3.3:
     dependencies:
@@ -1788,6 +2164,14 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1809,19 +2193,41 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
+  encodeurl@2.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  entities@7.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -1851,6 +2257,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -1926,9 +2334,44 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -1945,6 +2388,17 @@ snapshots:
       flat-cache: 4.0.1
 
   file-uri-to-path@1.0.0: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -1963,10 +2417,34 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   github-from-package@0.0.0: {}
 
@@ -1983,9 +2461,41 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  gopd@1.2.0: {}
+
+  happy-dom@20.8.4:
+    dependencies:
+      '@types/node': 20.19.37
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -1999,6 +2509,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ipaddr.js@1.9.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -2006,6 +2518,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2077,6 +2591,18 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-response@3.1.0: {}
 
   minimatch@10.2.4:
@@ -2101,9 +2627,17 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -2128,6 +2662,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -2136,6 +2672,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.3
+
+  path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -2170,12 +2708,30 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -2221,15 +2777,82 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2246,6 +2869,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -2319,6 +2944,8 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  toidentifier@1.0.1: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -2330,6 +2957,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript-eslint@8.57.1(eslint@10.0.3)(typescript@5.9.3):
     dependencies:
@@ -2346,11 +2979,15 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@20.19.37):
     dependencies:
@@ -2385,7 +3022,7 @@ snapshots:
       '@types/node': 20.19.37
       fsevents: 2.3.3
 
-  vitest@3.2.4(@types/node@20.19.37):
+  vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -2412,6 +3049,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
+      happy-dom: 20.8.4
     transitivePeerDependencies:
       - jiti
       - less
@@ -2425,6 +3063,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
@@ -2450,6 +3090,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.19.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/build-widget.mjs
+++ b/scripts/build-widget.mjs
@@ -1,0 +1,16 @@
+import { build } from 'esbuild';
+
+const isProd = process.env.NODE_ENV === 'production';
+
+await build({
+  entryPoints: ['src/widget/widget.ts'],
+  bundle: true,
+  format: 'iife',
+  globalName: 'PunchlistWidget',
+  outfile: 'dist/widget.js',
+  minify: isProd,
+  target: 'es2020',
+  sourcemap: !isProd,
+});
+
+console.log('  Widget bundled → dist/widget.js');

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { loadConfig } from '../../shared/config.js';
 import { DEFAULT_PORT, CONFIG_FILENAME } from '../../shared/constants.js';
+import { GitHubIssueAdapter } from '../../adapters/issues/index.js';
+import { createApp } from '../../server/app.js';
 
 export async function serveCommand(): Promise<void> {
   const cwd = process.cwd();
@@ -14,9 +16,28 @@ export async function serveCommand(): Promise<void> {
   }
 
   const config = loadConfig(cwd);
-  console.log(`\n  🚀 Punchlist QA Server`);
-  console.log(`  Project: ${config.projectName}`);
-  console.log(`  Port: ${DEFAULT_PORT}`);
-  console.log(`\n  ⚠ Server implementation coming in Epic 3.`);
-  console.log('  For now, this validates your config is correct.\n');
+
+  if (!config.secrets.githubToken) {
+    console.error('\n  Missing PUNCHLIST_GITHUB_TOKEN. Set it in .env or environment.\n');
+    process.exit(1);
+  }
+
+  const issueAdapter = new GitHubIssueAdapter(
+    config.issueTracker.repo,
+    config.secrets.githubToken,
+  );
+
+  const app = createApp({
+    issueAdapter,
+    corsDomains: config.widget.corsDomains,
+  });
+
+  app.listen(DEFAULT_PORT, () => {
+    console.log(`\n  Punchlist QA Server`);
+    console.log(`  Project: ${config.projectName}`);
+    console.log(`  Port: ${DEFAULT_PORT}`);
+    console.log(`  CORS: ${config.widget.corsDomains.join(', ')}`);
+    console.log(`\n  Widget: http://localhost:${DEFAULT_PORT}/widget.js`);
+    console.log(`  API:    http://localhost:${DEFAULT_PORT}/api/support/ticket\n`);
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   createQAFailureOptsSchema,
   createSupportTicketOptsSchema,
   labelDefSchema,
+  supportTicketRequestSchema,
 } from './shared/schemas.js';
 export { ConfigFetcher, ConfigFetcherError } from './shared/config-fetcher.js';
 export type { ConfigFetcherOpts } from './shared/config-fetcher.js';
@@ -47,6 +48,7 @@ export type {
   CreateQAFailureOpts,
   CreateSupportTicketOpts,
   LabelDef,
+  SupportTicketRequest,
 } from './shared/types.js';
 export { SqliteAdapter } from './adapters/storage/index.js';
 export type { StorageAdapter } from './adapters/storage/types.js';
@@ -69,3 +71,5 @@ export {
   UnrecognizedTokenError,
   RevokedUserError,
 } from './adapters/auth/errors.js';
+export { createApp } from './server/app.js';
+export type { AppDependencies } from './server/app.js';

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import type { Express } from 'express';
+import { corsMiddleware } from './middleware/cors.js';
+import { errorHandler } from './middleware/error-handler.js';
+import { supportRouter } from './routes/support.js';
+import { widgetServeRouter } from './routes/widget-serve.js';
+import type { IssueAdapter } from '../adapters/issues/types.js';
+
+export interface AppDependencies {
+  issueAdapter: IssueAdapter;
+  corsDomains: string[];
+}
+
+/**
+ * Factory: creates a configured Express app without calling `.listen()`.
+ * Accepts injected dependencies for testability.
+ */
+export function createApp(deps: AppDependencies): Express {
+  const app = express();
+
+  // Parse JSON bodies (explicit limit to document intent)
+  app.use(express.json({ limit: '100kb' }));
+
+  // CORS middleware on API routes only
+  app.use('/api/support', corsMiddleware(deps.corsDomains));
+
+  // Routes
+  app.use('/api/support', supportRouter(deps.issueAdapter));
+  app.use('/', widgetServeRouter());
+
+  // Error handler (must be last)
+  app.use(errorHandler);
+
+  return app;
+}

--- a/src/server/middleware/cors.ts
+++ b/src/server/middleware/cors.ts
@@ -1,0 +1,40 @@
+import type { Request, Response, NextFunction } from 'express';
+
+/**
+ * Custom CORS middleware — no external dependencies.
+ * Checks the `Origin` header against `allowedOrigins`.
+ * If the origin matches, sets appropriate CORS headers.
+ * Returns 204 for preflight OPTIONS requests.
+ * Rejects unmatched origins by not setting any CORS headers (browser blocks).
+ */
+export function corsMiddleware(allowedOrigins: string[]) {
+  const originSet = new Set(allowedOrigins);
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const origin = req.headers.origin;
+
+    if (!origin || !originSet.has(origin)) {
+      // No origin header or origin not allowed — skip CORS headers.
+      // For non-preflight requests, let them through (same-origin or server-to-server).
+      // For preflight, the browser will block due to missing headers.
+      if (req.method === 'OPTIONS') {
+        res.status(403).end();
+        return;
+      }
+      next();
+      return;
+    }
+
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Vary', 'Origin');
+
+    if (req.method === 'OPTIONS') {
+      res.status(204).end();
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/server/middleware/error-handler.ts
+++ b/src/server/middleware/error-handler.ts
@@ -1,0 +1,34 @@
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+
+/**
+ * Express error handler (4-arg signature).
+ * - Zod validation errors → 400 with structured details
+ * - Generic errors → 500 with sanitized message
+ */
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  if (err instanceof z.ZodError) {
+    res.status(400).json({
+      success: false,
+      error: 'Validation error',
+      details: err.issues.map((issue) => ({
+        path: issue.path.join('.'),
+        message: issue.message,
+      })),
+    });
+    return;
+  }
+
+  const message = err instanceof Error ? err.message : 'Internal server error';
+  console.error('[punchlist] Server error:', err);
+
+  res.status(500).json({
+    success: false,
+    error: message,
+  });
+}

--- a/src/server/routes/support.ts
+++ b/src/server/routes/support.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+import { supportTicketRequestSchema } from '../../shared/schemas.js';
+import type { CreateSupportTicketOpts } from '../../shared/schemas.js';
+import type { IssueAdapter } from '../../adapters/issues/types.js';
+
+/**
+ * Maps the nested widget request to the flat CreateSupportTicketOpts
+ * expected by the issue adapter.
+ */
+export function mapRequestToOpts(
+  body: ReturnType<typeof supportTicketRequestSchema.parse>,
+): CreateSupportTicketOpts {
+  const ctx = body.context;
+  return {
+    subject: body.subject,
+    description: body.description,
+    category: body.category,
+    userName: body.userName,
+    userEmail: body.userEmail,
+    userAgent: ctx?.userAgent,
+    pageUrl: ctx?.pageUrl,
+    screenSize: ctx?.screenSize,
+    consoleErrors: ctx?.consoleErrors?.join('\n'),
+    customContext: ctx?.customContext,
+  };
+}
+
+export function supportRouter(issueAdapter: IssueAdapter): Router {
+  const router = Router();
+
+  router.post('/ticket', async (req, res, next) => {
+    try {
+      const parsed = supportTicketRequestSchema.parse(req.body);
+      const opts = mapRequestToOpts(parsed);
+      const result = await issueAdapter.createSupportTicketIssue(opts);
+
+      res.status(201).json({
+        success: true,
+        issueUrl: result.url,
+        issueNumber: result.number,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/src/server/routes/widget-serve.ts
+++ b/src/server/routes/widget-serve.ts
@@ -1,0 +1,46 @@
+import { Router } from 'express';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+// Default: resolve dist/ relative to the package root (compiled module at dist/server/routes/)
+const DEFAULT_DIST_DIR = join(MODULE_DIR, '..', '..');
+
+/**
+ * Serves the bundled widget JS file.
+ * Caches the file in memory after first read in production.
+ */
+export function widgetServeRouter(distDir = DEFAULT_DIST_DIR): Router {
+  const router = Router();
+  let cachedWidget: string | null = null;
+  const isProd = process.env.NODE_ENV === 'production';
+
+  router.get('/widget.js', (_req, res) => {
+    if (cachedWidget) {
+      res.setHeader('Content-Type', 'application/javascript');
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.send(cachedWidget);
+      return;
+    }
+
+    const widgetPath = join(distDir, 'widget.js');
+    if (!existsSync(widgetPath)) {
+      res.status(404).json({ error: 'Widget not built. Run "pnpm build:widget" first.' });
+      return;
+    }
+
+    const content = readFileSync(widgetPath, 'utf-8');
+    if (isProd) {
+      cachedWidget = content;
+    }
+
+    res.setHeader('Content-Type', 'application/javascript');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.send(content);
+  });
+
+  return router;
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -192,6 +192,29 @@ export const createSupportTicketOptsSchema = z.object({
   customContext: z.record(z.string(), z.string()).optional(),
 });
 
+// --- Widget request schema (incoming from browser widget → server) ---
+
+export const supportTicketRequestSchema = z.object({
+  subject: z.string().min(1).max(200),
+  category: z.string().min(1),
+  description: z.string().max(5000).optional().default(''),
+  userName: z.string().max(100).optional(),
+  userEmail: z.string().email().optional(),
+  context: z
+    .object({
+      userAgent: z.string().optional(),
+      pageUrl: z.string().optional(),
+      screenSize: z.string().optional(),
+      viewportSize: z.string().optional(),
+      consoleErrors: z.array(z.string()).max(10).optional(),
+      lastError: z.string().optional(),
+      timestamp: z.string().optional(),
+      timezone: z.string().optional(),
+      customContext: z.record(z.string(), z.string()).optional(),
+    })
+    .optional(),
+});
+
 // --- Label schema ---
 
 export const labelDefSchema = z.object({
@@ -312,3 +335,4 @@ export type OpenIssue = z.infer<typeof openIssueSchema>;
 export type CreateQAFailureOpts = z.infer<typeof createQAFailureOptsSchema>;
 export type CreateSupportTicketOpts = z.infer<typeof createSupportTicketOptsSchema>;
 export type LabelDef = z.infer<typeof labelDefSchema>;
+export type SupportTicketRequest = z.infer<typeof supportTicketRequestSchema>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,4 +32,5 @@ export type {
   CreateQAFailureOpts,
   CreateSupportTicketOpts,
   LabelDef,
+  SupportTicketRequest,
 } from './schemas.js';

--- a/src/widget/context.ts
+++ b/src/widget/context.ts
@@ -1,0 +1,73 @@
+import type { CapturedContext } from './types.js';
+
+const MAX_ERRORS = 10;
+let errorBuffer: string[] = [];
+let lastError: string | undefined;
+let initialized = false;
+let errorHandler: ((event: ErrorEvent) => void) | null = null;
+let rejectionHandler: ((event: PromiseRejectionEvent) => void) | null = null;
+
+/**
+ * Start capturing window.error and unhandledrejection events.
+ * Buffers the last MAX_ERRORS messages.
+ *
+ * Note: Does NOT monkey-patch console.error/console.warn to avoid
+ * conflicts with host application logging and other libraries.
+ */
+export function initContextCapture(): void {
+  if (initialized) return;
+  initialized = true;
+
+  errorHandler = (event: ErrorEvent) => {
+    const msg = event.message || 'Unknown error';
+    lastError = msg;
+    pushError(msg);
+  };
+
+  rejectionHandler = (event: PromiseRejectionEvent) => {
+    const msg = event.reason instanceof Error ? event.reason.message : String(event.reason);
+    lastError = msg;
+    pushError(`[unhandled rejection] ${msg}`);
+  };
+
+  window.addEventListener('error', errorHandler);
+  window.addEventListener('unhandledrejection', rejectionHandler);
+}
+
+function pushError(msg: string): void {
+  errorBuffer.push(msg);
+  if (errorBuffer.length > MAX_ERRORS) {
+    errorBuffer = errorBuffer.slice(-MAX_ERRORS);
+  }
+}
+
+/**
+ * Remove event listeners and clear captured state.
+ */
+export function destroyContextCapture(): void {
+  if (!initialized) return;
+  if (errorHandler) window.removeEventListener('error', errorHandler);
+  if (rejectionHandler) window.removeEventListener('unhandledrejection', rejectionHandler);
+  errorHandler = null;
+  rejectionHandler = null;
+  errorBuffer = [];
+  lastError = undefined;
+  initialized = false;
+}
+
+/**
+ * Collect current browser context snapshot.
+ */
+export function captureContext(customContext?: Record<string, unknown>): CapturedContext {
+  return {
+    userAgent: navigator.userAgent,
+    pageUrl: window.location.href,
+    screenSize: `${screen.width}x${screen.height}`,
+    viewportSize: `${window.innerWidth}x${window.innerHeight}`,
+    consoleErrors: [...errorBuffer],
+    lastError,
+    timestamp: new Date().toISOString(),
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    ...(customContext ? { customContext } : {}),
+  };
+}

--- a/src/widget/dialog.ts
+++ b/src/widget/dialog.ts
@@ -1,0 +1,248 @@
+import type { WidgetConfig, WidgetState, SubmitResult, CapturedContext } from './types.js';
+import { captureContext } from './context.js';
+
+const SUPPORT_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>`;
+
+interface FormValues {
+  subject: string;
+  category: string;
+  description: string;
+  userName: string;
+  userEmail: string;
+}
+
+export class WidgetDialog {
+  private root: ShadowRoot;
+  private config: WidgetConfig;
+  private state: WidgetState = 'idle';
+  private overlay: HTMLElement | null = null;
+  private lastError: string | null = null;
+  private onCloseCallback: (() => void) | null = null;
+  private savedValues: FormValues | null = null;
+
+  constructor(root: ShadowRoot, config: WidgetConfig) {
+    this.root = root;
+    this.config = config;
+  }
+
+  onClose(cb: () => void): void {
+    this.onCloseCallback = cb;
+  }
+
+  open(): void {
+    if (this.overlay) return;
+    this.state = 'open';
+    this.renderOverlay();
+  }
+
+  close(): void {
+    if (this.overlay) {
+      this.overlay.remove();
+      this.overlay = null;
+    }
+    this.state = 'idle';
+    this.lastError = null;
+    this.savedValues = null;
+    this.onCloseCallback?.();
+  }
+
+  private renderOverlay(): void {
+    this.overlay = document.createElement('div');
+    this.overlay.className = 'punchlist-overlay';
+    this.overlay.addEventListener('click', (e) => {
+      if (e.target === this.overlay) this.close();
+    });
+
+    const dialog = document.createElement('div');
+    dialog.className = 'punchlist-dialog';
+    dialog.addEventListener('click', (e) => e.stopPropagation());
+
+    this.overlay.appendChild(dialog);
+    this.root.appendChild(this.overlay);
+
+    this.renderDialogContent(dialog);
+
+    // Escape key handler
+    const onKeydown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        this.close();
+        document.removeEventListener('keydown', onKeydown);
+      }
+    };
+    document.addEventListener('keydown', onKeydown);
+  }
+
+  private renderDialogContent(dialog: HTMLElement): void {
+    dialog.innerHTML = '';
+
+    switch (this.state) {
+      case 'open':
+        this.renderForm(dialog);
+        break;
+      case 'submitting':
+        this.renderForm(dialog, true);
+        break;
+      case 'success':
+        this.renderSuccess(dialog);
+        break;
+      case 'error':
+        this.renderError(dialog);
+        break;
+    }
+  }
+
+  private captureFormValues(dialog: HTMLElement): void {
+    const getValue = (id: string): string => {
+      const el = dialog.querySelector(`#${id}`) as HTMLInputElement | HTMLTextAreaElement | null;
+      return el?.value?.trim() ?? '';
+    };
+    this.savedValues = {
+      subject: getValue('punchlist-subject'),
+      category: getValue('punchlist-category'),
+      description: getValue('punchlist-description'),
+      userName: getValue('punchlist-name'),
+      userEmail: getValue('punchlist-email'),
+    };
+  }
+
+  private renderForm(dialog: HTMLElement, disabled = false): void {
+    const hasUser = !!(this.config.user?.name && this.config.user?.email);
+    const categories = this.config.categories ?? [];
+    const v = this.savedValues;
+
+    dialog.innerHTML = `
+      <div class="punchlist-dialog-header">
+        <h2>${SUPPORT_ICON_SVG} Submit Feedback</h2>
+        <button class="punchlist-close-btn" aria-label="Close">&times;</button>
+      </div>
+      <div class="punchlist-dialog-body">
+        <form class="punchlist-form">
+          <label class="punchlist-required" for="punchlist-subject">Subject</label>
+          <input type="text" id="punchlist-subject" placeholder="Brief summary of the issue" maxlength="200" required ${disabled ? 'disabled' : ''} value="${escapeAttr(v?.subject ?? '')}" />
+
+          <label class="punchlist-required" for="punchlist-category">Category</label>
+          ${
+            categories.length > 0
+              ? `<select id="punchlist-category" required ${disabled ? 'disabled' : ''}>
+                  <option value="">Select a category</option>
+                  ${categories.map((c) => `<option value="${escapeHtml(c)}"${v?.category === c ? ' selected' : ''}>${escapeHtml(c)}</option>`).join('')}
+                </select>`
+              : `<input type="text" id="punchlist-category" placeholder="e.g. bug, feature, question" required ${disabled ? 'disabled' : ''} value="${escapeAttr(v?.category ?? '')}" />`
+          }
+
+          <label for="punchlist-description">Description</label>
+          <textarea id="punchlist-description" placeholder="Describe the issue in detail (optional)" maxlength="5000" ${disabled ? 'disabled' : ''}>${escapeHtml(v?.description ?? '')}</textarea>
+
+          ${
+            !hasUser
+              ? `
+              <label for="punchlist-name">Name</label>
+              <input type="text" id="punchlist-name" placeholder="Your name (optional)" maxlength="100" ${disabled ? 'disabled' : ''} value="${escapeAttr(v?.userName ?? '')}" />
+
+              <label for="punchlist-email">Email</label>
+              <input type="email" id="punchlist-email" placeholder="Your email (optional)" ${disabled ? 'disabled' : ''} value="${escapeAttr(v?.userEmail ?? '')}" />
+            `
+              : ''
+          }
+
+          <button type="submit" class="punchlist-submit-btn" ${disabled ? 'disabled' : ''}>
+            ${disabled ? 'Submitting...' : 'Submit'}
+          </button>
+        </form>
+      </div>
+    `;
+
+    dialog.querySelector('.punchlist-close-btn')!.addEventListener('click', () => this.close());
+    dialog.querySelector('.punchlist-form')!.addEventListener('submit', (e) => {
+      e.preventDefault();
+      this.handleSubmit(dialog);
+    });
+  }
+
+  private async handleSubmit(dialog: HTMLElement): Promise<void> {
+    // Capture form values before re-rendering to preserve on retry
+    this.captureFormValues(dialog);
+
+    this.state = 'submitting';
+    this.renderDialogContent(dialog);
+
+    const v = this.savedValues!;
+    const subject = v.subject;
+    const category = v.category;
+    const description = v.description;
+    const userName = this.config.user?.name ?? v.userName;
+    const userEmail = this.config.user?.email ?? v.userEmail;
+
+    const context: CapturedContext = captureContext(this.config.customContext);
+
+    const body = {
+      subject,
+      category,
+      description: description || undefined,
+      userName: userName || undefined,
+      userEmail: userEmail || undefined,
+      context,
+    };
+
+    try {
+      const res = await fetch(`${this.config.serverUrl}/api/support/ticket`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error(data.error || `Server returned ${res.status}`);
+      }
+
+      const result: SubmitResult = await res.json();
+      this.state = 'success';
+      this.renderDialogContent(dialog);
+      this.config.onSubmit?.(result);
+
+      setTimeout(() => this.close(), 3000);
+    } catch (err) {
+      this.lastError = err instanceof Error ? err.message : 'Something went wrong';
+      this.state = 'error';
+      this.renderDialogContent(dialog);
+      this.config.onError?.(err instanceof Error ? err : new Error(this.lastError));
+    }
+  }
+
+  private renderSuccess(dialog: HTMLElement): void {
+    dialog.innerHTML = `
+      <div class="punchlist-success">
+        <div class="punchlist-success-icon">&#10003;</div>
+        <h3>Thank you!</h3>
+        <p>Your feedback has been submitted. This dialog will close automatically.</p>
+      </div>
+    `;
+  }
+
+  private renderError(dialog: HTMLElement): void {
+    dialog.innerHTML = `
+      <div class="punchlist-error">
+        <div class="punchlist-error-icon">!</div>
+        <h3>Something went wrong</h3>
+        <p>${escapeHtml(this.lastError ?? 'Unknown error')}</p>
+        <button class="punchlist-retry-btn">Try Again</button>
+      </div>
+    `;
+
+    dialog.querySelector('.punchlist-retry-btn')!.addEventListener('click', () => {
+      this.state = 'open';
+      this.renderDialogContent(dialog);
+    });
+  }
+}
+
+function escapeHtml(str: string): string {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+function escapeAttr(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}

--- a/src/widget/styles.ts
+++ b/src/widget/styles.ts
@@ -1,0 +1,266 @@
+/**
+ * Generate scoped CSS for the widget shadow DOM.
+ * Supports light/dark themes and customizable primary color + font.
+ */
+export function getWidgetStyles(opts: {
+  theme: 'light' | 'dark';
+  primaryColor: string;
+  fontFamily: string;
+}): string {
+  const { theme, primaryColor, fontFamily } = opts;
+
+  const isDark = theme === 'dark';
+  const bg = isDark ? '#1e1e2e' : '#ffffff';
+  const bgSecondary = isDark ? '#2a2a3e' : '#f5f5f7';
+  const text = isDark ? '#e0e0e0' : '#1a1a1a';
+  const textSecondary = isDark ? '#a0a0b0' : '#666666';
+  const border = isDark ? '#3a3a4e' : '#e0e0e0';
+  const inputBg = isDark ? '#2a2a3e' : '#ffffff';
+  const overlayBg = 'rgba(0, 0, 0, 0.5)';
+
+  return `
+    :host {
+      all: initial;
+      font-family: ${fontFamily};
+      color: ${text};
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    /* FAB trigger button */
+    .punchlist-fab {
+      position: fixed;
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: ${primaryColor};
+      color: #ffffff;
+      border: none;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+      z-index: 2147483647;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .punchlist-fab:hover {
+      transform: scale(1.08);
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+    }
+
+    .punchlist-fab.bottom-right { bottom: 24px; right: 24px; }
+    .punchlist-fab.bottom-left { bottom: 24px; left: 24px; }
+    .punchlist-fab.top-right { top: 24px; right: 24px; }
+    .punchlist-fab.top-left { top: 24px; left: 24px; }
+
+    .punchlist-fab svg {
+      width: 24px;
+      height: 24px;
+      fill: currentColor;
+    }
+
+    /* Inline / menu-item trigger */
+    .punchlist-inline-btn,
+    .punchlist-menu-btn {
+      background: ${primaryColor};
+      color: #ffffff;
+      border: none;
+      cursor: pointer;
+      font-family: ${fontFamily};
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .punchlist-inline-btn {
+      padding: 10px 20px;
+      border-radius: 8px;
+    }
+
+    .punchlist-menu-btn {
+      padding: 8px 16px;
+      border-radius: 4px;
+      width: 100%;
+      text-align: left;
+    }
+
+    /* Overlay */
+    .punchlist-overlay {
+      position: fixed;
+      inset: 0;
+      background: ${overlayBg};
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 2147483647;
+      animation: punchlist-fade-in 0.2s ease;
+    }
+
+    @keyframes punchlist-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    /* Dialog */
+    .punchlist-dialog {
+      background: ${bg};
+      border-radius: 12px;
+      width: 90%;
+      max-width: 480px;
+      max-height: 90vh;
+      overflow-y: auto;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      animation: punchlist-slide-up 0.25s ease;
+    }
+
+    @keyframes punchlist-slide-up {
+      from { transform: translateY(20px); opacity: 0; }
+      to { transform: translateY(0); opacity: 1; }
+    }
+
+    .punchlist-dialog-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 20px 24px 0;
+    }
+
+    .punchlist-dialog-header h2 {
+      font-size: 18px;
+      font-weight: 600;
+      color: ${text};
+    }
+
+    .punchlist-close-btn {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: ${textSecondary};
+      font-size: 20px;
+      padding: 4px;
+      line-height: 1;
+    }
+
+    .punchlist-dialog-body {
+      padding: 20px 24px 24px;
+    }
+
+    /* Form */
+    .punchlist-form label {
+      display: block;
+      font-size: 13px;
+      font-weight: 500;
+      color: ${textSecondary};
+      margin-bottom: 4px;
+    }
+
+    .punchlist-form input,
+    .punchlist-form textarea,
+    .punchlist-form select {
+      width: 100%;
+      padding: 10px 12px;
+      border: 1px solid ${border};
+      border-radius: 8px;
+      font-family: ${fontFamily};
+      font-size: 14px;
+      color: ${text};
+      background: ${inputBg};
+      margin-bottom: 16px;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+
+    .punchlist-form input:focus,
+    .punchlist-form textarea:focus,
+    .punchlist-form select:focus {
+      border-color: ${primaryColor};
+    }
+
+    .punchlist-form textarea {
+      resize: vertical;
+      min-height: 80px;
+    }
+
+    .punchlist-form .punchlist-required::after {
+      content: ' *';
+      color: #e11d48;
+    }
+
+    .punchlist-submit-btn {
+      width: 100%;
+      padding: 12px;
+      background: ${primaryColor};
+      color: #ffffff;
+      border: none;
+      border-radius: 8px;
+      font-family: ${fontFamily};
+      font-size: 15px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.2s;
+    }
+
+    .punchlist-submit-btn:hover { opacity: 0.9; }
+    .punchlist-submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* States */
+    .punchlist-success {
+      text-align: center;
+      padding: 40px 24px;
+    }
+
+    .punchlist-success-icon {
+      font-size: 48px;
+      margin-bottom: 12px;
+    }
+
+    .punchlist-success h3 {
+      font-size: 18px;
+      color: ${text};
+      margin-bottom: 8px;
+    }
+
+    .punchlist-success p {
+      color: ${textSecondary};
+      font-size: 14px;
+    }
+
+    .punchlist-error {
+      text-align: center;
+      padding: 40px 24px;
+    }
+
+    .punchlist-error-icon {
+      font-size: 48px;
+      margin-bottom: 12px;
+    }
+
+    .punchlist-error h3 {
+      color: #e11d48;
+      font-size: 18px;
+      margin-bottom: 8px;
+    }
+
+    .punchlist-error p {
+      color: ${textSecondary};
+      font-size: 14px;
+      margin-bottom: 16px;
+    }
+
+    .punchlist-retry-btn {
+      padding: 10px 24px;
+      background: ${bgSecondary};
+      color: ${text};
+      border: 1px solid ${border};
+      border-radius: 8px;
+      font-family: ${fontFamily};
+      font-size: 14px;
+      cursor: pointer;
+    }
+  `;
+}

--- a/src/widget/types.ts
+++ b/src/widget/types.ts
@@ -1,0 +1,61 @@
+/** Configuration for `PunchlistWidget.init()` */
+export interface WidgetConfig {
+  /** URL of the punchlist-qa server (e.g. "http://localhost:4747") */
+  serverUrl: string;
+
+  /** Widget display variant */
+  variant?: 'fab' | 'inline' | 'menu-item';
+
+  /** CSS selector for the target container (required for inline and menu-item) */
+  target?: string;
+
+  /** FAB position */
+  position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
+
+  /** Color theme */
+  theme?: 'light' | 'dark';
+
+  /** Primary accent color (CSS color value) */
+  primaryColor?: string;
+
+  /** Font family override */
+  fontFamily?: string;
+
+  /** Predefined categories for the dropdown */
+  categories?: string[];
+
+  /** Pre-fill user context */
+  user?: {
+    name?: string;
+    email?: string;
+  };
+
+  /** Additional custom context sent with every ticket */
+  customContext?: Record<string, unknown>;
+
+  /** Callback after successful submission */
+  onSubmit?: (result: SubmitResult) => void;
+
+  /** Callback on error */
+  onError?: (error: Error) => void;
+}
+
+export interface SubmitResult {
+  issueUrl: string;
+  issueNumber: number;
+}
+
+export interface CapturedContext {
+  userAgent: string;
+  pageUrl: string;
+  screenSize: string;
+  viewportSize: string;
+  consoleErrors: string[];
+  lastError: string | undefined;
+  timestamp: string;
+  timezone: string;
+  customContext?: Record<string, unknown>;
+}
+
+/** Internal widget state */
+export type WidgetState = 'idle' | 'open' | 'submitting' | 'success' | 'error';

--- a/src/widget/variants.ts
+++ b/src/widget/variants.ts
@@ -1,0 +1,86 @@
+import type { WidgetConfig } from './types.js';
+
+const CHAT_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`;
+
+/** Simple CSS selector format validation — allows tag, class, id, and attribute selectors */
+const SAFE_SELECTOR_RE = /^[a-zA-Z0-9\s\-_#.,[\]="':>+~()*^$|]+$/;
+
+function queryTarget(selector: string): Element | null {
+  if (!SAFE_SELECTOR_RE.test(selector)) {
+    console.warn(`[PunchlistWidget] Invalid target selector "${selector}", rendering in shadow root.`);
+    return null;
+  }
+  try {
+    return document.querySelector(selector);
+  } catch {
+    console.warn(`[PunchlistWidget] Failed to query target "${selector}", rendering in shadow root.`);
+    return null;
+  }
+}
+
+/**
+ * Creates the trigger element for the configured variant.
+ * Returns the element that, when clicked, should open the dialog.
+ */
+export function createTrigger(
+  root: ShadowRoot,
+  config: WidgetConfig,
+  onClick: () => void,
+): HTMLElement {
+  const variant = config.variant ?? 'fab';
+
+  switch (variant) {
+    case 'fab':
+      return createFab(root, config, onClick);
+    case 'inline':
+      return createInline(root, config, onClick);
+    case 'menu-item':
+      return createMenuItem(root, config, onClick);
+  }
+}
+
+function createFab(root: ShadowRoot, config: WidgetConfig, onClick: () => void): HTMLElement {
+  const btn = document.createElement('button');
+  btn.className = `punchlist-fab ${config.position ?? 'bottom-right'}`;
+  btn.innerHTML = CHAT_ICON_SVG;
+  btn.setAttribute('aria-label', 'Submit feedback');
+  btn.addEventListener('click', onClick);
+  root.appendChild(btn);
+  return btn;
+}
+
+function createInline(root: ShadowRoot, config: WidgetConfig, onClick: () => void): HTMLElement {
+  const btn = document.createElement('button');
+  btn.className = 'punchlist-inline-btn';
+  btn.textContent = 'Submit Feedback';
+  btn.addEventListener('click', onClick);
+
+  if (config.target) {
+    const target = queryTarget(config.target);
+    if (target) {
+      target.appendChild(btn);
+      return btn;
+    }
+  }
+
+  root.appendChild(btn);
+  return btn;
+}
+
+function createMenuItem(root: ShadowRoot, config: WidgetConfig, onClick: () => void): HTMLElement {
+  const btn = document.createElement('button');
+  btn.className = 'punchlist-menu-btn';
+  btn.textContent = 'Report an Issue';
+  btn.addEventListener('click', onClick);
+
+  if (config.target) {
+    const target = queryTarget(config.target);
+    if (target) {
+      target.appendChild(btn);
+      return btn;
+    }
+  }
+
+  root.appendChild(btn);
+  return btn;
+}

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -1,0 +1,122 @@
+import type { WidgetConfig } from './types.js';
+import { getWidgetStyles } from './styles.js';
+import { WidgetDialog } from './dialog.js';
+import { createTrigger } from './variants.js';
+import { initContextCapture, destroyContextCapture } from './context.js';
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{3,8}$/;
+const SAFE_FONT_FAMILY_RE = /^[\w\s\-,'"().]+$/;
+
+let host: HTMLElement | null = null;
+let dialog: WidgetDialog | null = null;
+let triggerEl: HTMLElement | null = null;
+
+function validateServerUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`[PunchlistWidget] serverUrl must use http: or https: protocol, got "${parsed.protocol}"`);
+    }
+    return parsed.origin;
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('[PunchlistWidget]')) throw err;
+    throw new Error(`[PunchlistWidget] Invalid serverUrl: "${url}"`, { cause: err });
+  }
+}
+
+function sanitizePrimaryColor(color: string | undefined): string {
+  const fallback = '#6f42c1';
+  if (!color) return fallback;
+  if (HEX_COLOR_RE.test(color)) return color;
+  console.warn(`[PunchlistWidget] Invalid primaryColor "${color}", using default.`);
+  return fallback;
+}
+
+function sanitizeFontFamily(font: string | undefined): string {
+  const fallback = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  if (!font) return fallback;
+  if (SAFE_FONT_FAMILY_RE.test(font)) return font;
+  console.warn(`[PunchlistWidget] Invalid fontFamily "${font}", using default.`);
+  return fallback;
+}
+
+/**
+ * Initialize the Punchlist support widget.
+ * Creates a shadow DOM host, injects styles, renders the trigger and dialog.
+ */
+function init(config: WidgetConfig): void {
+  if (host) {
+    console.warn('[PunchlistWidget] Already initialized. Call destroy() first.');
+    return;
+  }
+
+  // Validate serverUrl before anything else
+  const serverUrl = validateServerUrl(config.serverUrl);
+  const validatedConfig = { ...config, serverUrl };
+
+  // Start capturing console errors and global errors
+  initContextCapture();
+
+  // Create shadow DOM host
+  host = document.createElement('div');
+  host.id = 'punchlist-widget';
+  const shadow = host.attachShadow({ mode: 'open' });
+
+  // Inject scoped styles with sanitized values
+  const style = document.createElement('style');
+  style.textContent = getWidgetStyles({
+    theme: config.theme ?? 'light',
+    primaryColor: sanitizePrimaryColor(config.primaryColor),
+    fontFamily: sanitizeFontFamily(config.fontFamily),
+  });
+  shadow.appendChild(style);
+
+  // Create dialog controller
+  dialog = new WidgetDialog(shadow, validatedConfig);
+
+  // Create trigger element
+  const isFab = config.variant !== 'inline' && config.variant !== 'menu-item';
+  triggerEl = createTrigger(shadow, validatedConfig, () => {
+    if (isFab && triggerEl) triggerEl.style.display = 'none';
+    dialog!.open();
+  });
+
+  // Restore FAB trigger when dialog closes
+  dialog.onClose(() => {
+    if (isFab && triggerEl) triggerEl.style.display = '';
+  });
+
+  document.body.appendChild(host);
+}
+
+/** Open the dialog programmatically */
+function open(): void {
+  if (!dialog) {
+    console.warn('[PunchlistWidget] Not initialized. Call init() first.');
+    return;
+  }
+  dialog.open();
+}
+
+/** Close the dialog programmatically */
+function close(): void {
+  if (!dialog) return;
+  dialog.close();
+}
+
+/** Destroy the widget and clean up */
+function destroy(): void {
+  dialog?.close();
+  dialog = null;
+  triggerEl = null;
+
+  if (host) {
+    host.remove();
+    host = null;
+  }
+
+  destroyContextCapture();
+}
+
+// Export public API for IIFE bundle
+export { init, open, close, destroy };

--- a/tests/unit/server/app.test.ts
+++ b/tests/unit/server/app.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import http from 'node:http';
+import type { IssueAdapter } from '../../../src/adapters/issues/types.js';
+import { createApp } from '../../../src/server/app.js';
+
+function createMockAdapter(): IssueAdapter {
+  return {
+    initialize: vi.fn(),
+    createIssue: vi.fn(),
+    createQAFailureIssue: vi.fn(),
+    createSupportTicketIssue: vi.fn().mockResolvedValue({
+      url: 'https://github.com/owner/repo/issues/1',
+      id: '1',
+      number: 1,
+    }),
+    getOpenIssueForTest: vi.fn(),
+    addLabels: vi.fn(),
+    validateLabels: vi.fn(),
+  };
+}
+
+function makeRequest(
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    const data = body ? JSON.stringify(body) : undefined;
+
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: {
+          ...(data ? { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(data)) } : {}),
+          ...headers,
+        },
+      },
+      (res) => {
+        let resBody = '';
+        res.on('data', (chunk) => (resBody += chunk));
+        res.on('end', () => resolve({ status: res.statusCode!, headers: res.headers, body: resBody }));
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+describe('createApp integration', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('wires up support route with CORS', async () => {
+    const adapter = createMockAdapter();
+    const app = createApp({
+      issueAdapter: adapter,
+      corsDomains: ['http://localhost:3000'],
+    });
+    server = app.listen(0);
+
+    const res = await makeRequest(
+      server,
+      'POST',
+      '/api/support/ticket',
+      { subject: 'Test', category: 'bug' },
+      { Origin: 'http://localhost:3000' },
+    );
+
+    expect(res.status).toBe(201);
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:3000');
+    expect(JSON.parse(res.body).success).toBe(true);
+  });
+
+  it('blocks CORS preflight from unauthorized origins', async () => {
+    const adapter = createMockAdapter();
+    const app = createApp({
+      issueAdapter: adapter,
+      corsDomains: ['http://localhost:3000'],
+    });
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'OPTIONS', '/api/support/ticket', undefined, {
+      Origin: 'http://evil.com',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('serves widget.js endpoint', async () => {
+    const adapter = createMockAdapter();
+    const app = createApp({
+      issueAdapter: adapter,
+      corsDomains: [],
+    });
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'GET', '/widget.js');
+
+    // Either 200 (widget built) or 404 (not built) — both are valid behavior
+    expect([200, 404]).toContain(res.status);
+  });
+});

--- a/tests/unit/server/cors.test.ts
+++ b/tests/unit/server/cors.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { corsMiddleware } from '../../../src/server/middleware/cors.js';
+
+function mockReq(method: string, origin?: string): Partial<Request> {
+  return {
+    method,
+    headers: origin ? { origin } : {},
+  };
+}
+
+function mockRes(): Partial<Response> & { headers: Record<string, string>; statusCode: number } {
+  const res = {
+    headers: {} as Record<string, string>,
+    statusCode: 200,
+    setHeader(key: string, value: string) {
+      res.headers[key] = value;
+      return res;
+    },
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    end: vi.fn(),
+  };
+  return res as unknown as Partial<Response> & {
+    headers: Record<string, string>;
+    statusCode: number;
+  };
+}
+
+describe('corsMiddleware', () => {
+  const middleware = corsMiddleware(['http://localhost:3000', 'https://example.com']);
+
+  it('sets CORS headers for allowed origin', () => {
+    const req = mockReq('POST', 'http://localhost:3000');
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req as Request, res as unknown as Response, next as NextFunction);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('http://localhost:3000');
+    expect(res.headers['Access-Control-Allow-Methods']).toBe('POST, OPTIONS');
+    expect(res.headers['Access-Control-Allow-Headers']).toBe('Content-Type');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('responds 204 for OPTIONS preflight with allowed origin', () => {
+    const req = mockReq('OPTIONS', 'https://example.com');
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req as Request, res as unknown as Response, next as NextFunction);
+
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('https://example.com');
+    expect(res.end).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects OPTIONS preflight with disallowed origin', () => {
+    const req = mockReq('OPTIONS', 'http://evil.com');
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req as Request, res as unknown as Response, next as NextFunction);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(res.end).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('does not set CORS headers for disallowed origin on non-OPTIONS', () => {
+    const req = mockReq('POST', 'http://evil.com');
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req as Request, res as unknown as Response, next as NextFunction);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not set CORS headers when no origin header', () => {
+    const req = mockReq('POST');
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req as Request, res as unknown as Response, next as NextFunction);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server/map-request-to-opts.test.ts
+++ b/tests/unit/server/map-request-to-opts.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { mapRequestToOpts } from '../../../src/server/routes/support.js';
+
+describe('mapRequestToOpts', () => {
+  it('maps minimal request to flat opts', () => {
+    const result = mapRequestToOpts({
+      subject: 'Bug report',
+      category: 'bug',
+      description: '',
+    });
+
+    expect(result).toEqual({
+      subject: 'Bug report',
+      category: 'bug',
+      description: '',
+      userName: undefined,
+      userEmail: undefined,
+      userAgent: undefined,
+      pageUrl: undefined,
+      screenSize: undefined,
+      consoleErrors: undefined,
+      customContext: undefined,
+    });
+  });
+
+  it('maps user fields', () => {
+    const result = mapRequestToOpts({
+      subject: 'Help',
+      category: 'question',
+      description: 'Need help',
+      userName: 'Jane',
+      userEmail: 'jane@example.com',
+    });
+
+    expect(result.userName).toBe('Jane');
+    expect(result.userEmail).toBe('jane@example.com');
+  });
+
+  it('maps context fields to flat structure', () => {
+    const result = mapRequestToOpts({
+      subject: 'UI issue',
+      category: 'bug',
+      description: '',
+      context: {
+        userAgent: 'Chrome/120',
+        pageUrl: 'https://example.com/app',
+        screenSize: '1920x1080',
+        consoleErrors: ['Error A', 'Error B'],
+        customContext: { sessionId: 'xyz', tenant: 'acme' },
+      },
+    });
+
+    expect(result.userAgent).toBe('Chrome/120');
+    expect(result.pageUrl).toBe('https://example.com/app');
+    expect(result.screenSize).toBe('1920x1080');
+    expect(result.consoleErrors).toBe('Error A\nError B');
+    expect(result.customContext).toEqual({ sessionId: 'xyz', tenant: 'acme' });
+  });
+
+  it('joins console errors with newlines', () => {
+    const result = mapRequestToOpts({
+      subject: 'Errors',
+      category: 'bug',
+      description: '',
+      context: {
+        consoleErrors: ['TypeError: x', 'ReferenceError: y', 'SyntaxError: z'],
+      },
+    });
+
+    expect(result.consoleErrors).toBe('TypeError: x\nReferenceError: y\nSyntaxError: z');
+  });
+
+  it('handles empty console errors array', () => {
+    const result = mapRequestToOpts({
+      subject: 'Clean',
+      category: 'feature',
+      description: '',
+      context: {
+        consoleErrors: [],
+      },
+    });
+
+    expect(result.consoleErrors).toBe('');
+  });
+
+  it('handles context without optional fields', () => {
+    const result = mapRequestToOpts({
+      subject: 'Minimal context',
+      category: 'bug',
+      description: '',
+      context: {},
+    });
+
+    expect(result.userAgent).toBeUndefined();
+    expect(result.pageUrl).toBeUndefined();
+    expect(result.consoleErrors).toBeUndefined();
+    expect(result.customContext).toBeUndefined();
+  });
+});

--- a/tests/unit/server/support-route.test.ts
+++ b/tests/unit/server/support-route.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import type { IssueAdapter } from '../../../src/adapters/issues/types.js';
+import { supportRouter } from '../../../src/server/routes/support.js';
+import { errorHandler } from '../../../src/server/middleware/error-handler.js';
+
+function createMockAdapter(overrides: Partial<IssueAdapter> = {}): IssueAdapter {
+  return {
+    initialize: vi.fn(),
+    createIssue: vi.fn(),
+    createQAFailureIssue: vi.fn(),
+    createSupportTicketIssue: vi.fn().mockResolvedValue({
+      url: 'https://github.com/owner/repo/issues/42',
+      id: '12345',
+      number: 42,
+    }),
+    getOpenIssueForTest: vi.fn(),
+    addLabels: vi.fn(),
+    validateLabels: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeRequest(
+  server: http.Server,
+  body: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/api/support/ticket',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(body) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: body } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+describe('POST /api/support/ticket', () => {
+  let server: http.Server;
+  let mockAdapter: IssueAdapter;
+
+  beforeEach(() => {
+    mockAdapter = createMockAdapter();
+    const app = express();
+    app.use(express.json());
+    app.use('/api/support', supportRouter(mockAdapter));
+    app.use(errorHandler);
+    server = app.listen(0);
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('creates a support ticket with valid payload', async () => {
+    const res = await makeRequest(server, {
+      subject: 'Login broken',
+      category: 'bug',
+      description: 'Cannot login with valid credentials',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      success: true,
+      issueUrl: 'https://github.com/owner/repo/issues/42',
+      issueNumber: 42,
+    });
+
+    expect(mockAdapter.createSupportTicketIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Login broken',
+        category: 'bug',
+        description: 'Cannot login with valid credentials',
+      }),
+    );
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    const res = await makeRequest(server, { description: 'no subject or category' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Validation error');
+    expect(Array.isArray(res.body.details)).toBe(true);
+  });
+
+  it('returns 500 when adapter throws', async () => {
+    const failAdapter = createMockAdapter({
+      createSupportTicketIssue: vi.fn().mockRejectedValue(new Error('GitHub API down')),
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api/support', supportRouter(failAdapter));
+    app.use(errorHandler);
+    const failServer = app.listen(0);
+
+    try {
+      const res = await makeRequest(failServer, {
+        subject: 'Test',
+        category: 'bug',
+      });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('GitHub API down');
+    } finally {
+      await new Promise<void>((resolve) => failServer.close(() => resolve()));
+    }
+  });
+
+  it('maps nested context to flat adapter opts', async () => {
+    await makeRequest(server, {
+      subject: 'UI glitch',
+      category: 'bug',
+      context: {
+        userAgent: 'TestBrowser/1.0',
+        pageUrl: 'https://example.com/dashboard',
+        screenSize: '1920x1080',
+        consoleErrors: ['TypeError: null is not an object'],
+        customContext: { sessionId: 'abc123' },
+      },
+    });
+
+    expect(mockAdapter.createSupportTicketIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'UI glitch',
+        category: 'bug',
+        userAgent: 'TestBrowser/1.0',
+        pageUrl: 'https://example.com/dashboard',
+        screenSize: '1920x1080',
+        consoleErrors: 'TypeError: null is not an object',
+        customContext: { sessionId: 'abc123' },
+      }),
+    );
+  });
+});

--- a/tests/unit/server/widget-serve.test.ts
+++ b/tests/unit/server/widget-serve.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { widgetServeRouter } from '../../../src/server/routes/widget-serve.js';
+
+function makeGetRequest(
+  server: http.Server,
+  path: string,
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    http
+      .get({ hostname: '127.0.0.1', port, path }, (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => resolve({ status: res.statusCode!, headers: res.headers, body }));
+      })
+      .on('error', reject);
+  });
+}
+
+describe('GET /widget.js', () => {
+  let server: http.Server;
+  const distDir = join(process.cwd(), 'dist');
+
+  beforeEach(() => {
+    const app = express();
+    app.use('/', widgetServeRouter(distDir));
+    server = app.listen(0);
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('serves widget.js with correct content-type', async () => {
+    // Ensure dist/widget.js exists (from the build step)
+    if (!existsSync(join(distDir, 'widget.js'))) {
+      mkdirSync(distDir, { recursive: true });
+      writeFileSync(join(distDir, 'widget.js'), '// test widget', 'utf-8');
+    }
+
+    const res = await makeGetRequest(server, '/widget.js');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('application/javascript');
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+    expect(res.headers['cache-control']).toBe('public, max-age=3600');
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  it('returns 404 when widget.js does not exist', async () => {
+    // Temporarily rename the file if it exists
+    const widgetPath = join(distDir, 'widget.js');
+    const backupPath = join(distDir, 'widget.js.bak');
+    let backed = false;
+
+    if (existsSync(widgetPath)) {
+      const { renameSync } = await import('node:fs');
+      renameSync(widgetPath, backupPath);
+      backed = true;
+    }
+
+    try {
+      const res = await makeGetRequest(server, '/widget.js');
+      expect(res.status).toBe(404);
+    } finally {
+      if (backed) {
+        const { renameSync } = await import('node:fs');
+        renameSync(backupPath, widgetPath);
+      }
+    }
+  });
+});

--- a/tests/widget/context.test.ts
+++ b/tests/widget/context.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initContextCapture, destroyContextCapture, captureContext } from '../../src/widget/context.js';
+
+describe('context capture', () => {
+  beforeEach(() => {
+    initContextCapture();
+  });
+
+  afterEach(() => {
+    destroyContextCapture();
+  });
+
+  it('captures browser context snapshot', () => {
+    const ctx = captureContext();
+
+    expect(ctx.userAgent).toBeDefined();
+    expect(ctx.pageUrl).toBeDefined();
+    expect(ctx.screenSize).toMatch(/\d+x\d+/);
+    expect(ctx.viewportSize).toMatch(/\d+x\d+/);
+    expect(ctx.timestamp).toBeDefined();
+    expect(ctx.timezone).toBeDefined();
+    expect(Array.isArray(ctx.consoleErrors)).toBe(true);
+  });
+
+  it('captures window error events', () => {
+    const errorEvent = new ErrorEvent('error', { message: 'test window error' });
+    window.dispatchEvent(errorEvent);
+
+    const ctx = captureContext();
+    expect(ctx.consoleErrors).toContain('test window error');
+    expect(ctx.lastError).toBe('test window error');
+  });
+
+  it('includes custom context when provided', () => {
+    const ctx = captureContext({ sessionId: 'abc123' });
+    expect(ctx.customContext).toEqual({ sessionId: 'abc123' });
+  });
+
+  it('stops capturing after destroy', () => {
+    destroyContextCapture();
+
+    const errorEvent = new ErrorEvent('error', { message: 'after destroy' });
+    window.dispatchEvent(errorEvent);
+
+    initContextCapture();
+    const ctx = captureContext();
+    expect(ctx.consoleErrors).not.toContain('after destroy');
+  });
+
+  it('does not double-initialize', () => {
+    // Call init again — should be a no-op
+    initContextCapture();
+
+    const errorEvent = new ErrorEvent('error', { message: 'single capture' });
+    window.dispatchEvent(errorEvent);
+
+    const ctx = captureContext();
+    // Should only appear once, not twice
+    const count = ctx.consoleErrors.filter((e) => e === 'single capture').length;
+    expect(count).toBe(1);
+  });
+});

--- a/tests/widget/widget.test.ts
+++ b/tests/widget/widget.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { init, destroy } from '../../src/widget/widget.js';
+
+describe('PunchlistWidget', () => {
+  afterEach(() => {
+    destroy();
+  });
+
+  it('creates shadow DOM host on init', () => {
+    init({ serverUrl: 'http://localhost:4747' });
+
+    const host = document.getElementById('punchlist-widget');
+    expect(host).not.toBeNull();
+    expect(host!.shadowRoot).not.toBeNull();
+  });
+
+  it('creates FAB trigger by default', () => {
+    init({ serverUrl: 'http://localhost:4747' });
+
+    const host = document.getElementById('punchlist-widget');
+    const fab = host!.shadowRoot!.querySelector('.punchlist-fab');
+    expect(fab).not.toBeNull();
+  });
+
+  it('creates FAB with correct position', () => {
+    init({ serverUrl: 'http://localhost:4747', position: 'top-left' });
+
+    const host = document.getElementById('punchlist-widget');
+    const fab = host!.shadowRoot!.querySelector('.punchlist-fab.top-left');
+    expect(fab).not.toBeNull();
+  });
+
+  it('removes host on destroy', () => {
+    init({ serverUrl: 'http://localhost:4747' });
+    expect(document.getElementById('punchlist-widget')).not.toBeNull();
+
+    destroy();
+    expect(document.getElementById('punchlist-widget')).toBeNull();
+  });
+
+  it('warns on double init', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    init({ serverUrl: 'http://localhost:4747' });
+    init({ serverUrl: 'http://localhost:4747' });
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Already initialized'));
+    warnSpy.mockRestore();
+  });
+
+  it('handles inline variant with missing target gracefully', () => {
+    init({
+      serverUrl: 'http://localhost:4747',
+      variant: 'inline',
+      target: '#nonexistent',
+    });
+
+    const host = document.getElementById('punchlist-widget');
+    expect(host).not.toBeNull();
+  });
+
+  it('rejects invalid serverUrl', () => {
+    expect(() => init({ serverUrl: 'not-a-url' })).toThrow('Invalid serverUrl');
+  });
+
+  it('rejects non-http serverUrl', () => {
+    expect(() => init({ serverUrl: 'ftp://example.com' })).toThrow('http: or https:');
+  });
+
+  it('falls back to default primaryColor for invalid value', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    init({ serverUrl: 'http://localhost:4747', primaryColor: 'red} * {display:none' });
+
+    const host = document.getElementById('punchlist-widget');
+    expect(host).not.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid primaryColor'));
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to default fontFamily for invalid value', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    init({ serverUrl: 'http://localhost:4747', fontFamily: 'font; background: url(evil)' });
+
+    const host = document.getElementById('punchlist-widget');
+    expect(host).not.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid fontFamily'));
+    warnSpy.mockRestore();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/widget"]
 }

--- a/tsconfig.widget.json
+++ b/tsconfig.widget.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "noEmit": true
+  },
+  "include": ["src/widget/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    environmentMatchGlobs: [['tests/widget/**', 'happy-dom']],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary

- **Express server** (`src/server/`): `createApp()` factory with dependency injection, custom CORS middleware (no external deps), JSON body parsing with 100kb limit, error handler (Zod → 400, generic → 500)
- **Support ticket API** (`POST /api/support/ticket`): Zod-validated request body, maps nested widget request to flat `CreateSupportTicketOpts`, calls `issueAdapter.createSupportTicketIssue()`
- **Widget serving** (`GET /widget.js`): Content-type headers, CORS `*` for script loading, in-memory caching in production, configurable dist directory via `import.meta.url`
- **Widget** (`src/widget/`): Zero-dependency, shadow DOM-isolated, IIFE bundle via esbuild. Three variants (FAB, inline, menu-item). Form with subject/category/description, success/error states with retry. Auto-captures browser context via `window.error` and `unhandledrejection` events
- **Security hardening**: `primaryColor` hex validation, `fontFamily` safe-character regex, `serverUrl` URL constructor validation with protocol check, CSS selector validation for `target`, `customContext` schema tightened from `z.unknown()` to `z.string()`, form attribute escaping
- **Build infrastructure**: esbuild widget bundler, `tsconfig.widget.json` with DOM lib, widget excluded from main tsconfig
- **Tests**: 31 new tests across 7 test files (CORS, support route, widget serve, app integration, mapRequestToOpts, context capture, widget lifecycle + validation)

Closes #7, closes #27, closes #28, closes #29, closes #30, closes #31, closes #13, closes #32

## Test plan
- [x] `pnpm build` — compiles server + bundles widget (313 tests, 23 files)
- [x] `pnpm test` — all 313 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [ ] Smoke: `curl http://localhost:4747/widget.js` returns JS
- [ ] Smoke: `curl -X POST http://localhost:4747/api/support/ticket -H 'Content-Type: application/json' -H 'Origin: http://localhost:3000' -d '{"subject":"test","category":"bug"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)