### PR TITLE
feat: QA dashboard backend API + React SPA scaffold (#33, #38)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default tseslint.config(
   {
-    ignores: ['dist/', 'coverage/', 'node_modules/'],
+    ignores: ['dist/', 'coverage/', 'node_modules/', 'src/dashboard/'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
     "punchlist.config.example.json"
   ],
   "scripts": {
-    "build": "tsc && node scripts/build-widget.mjs",
+    "build": "tsc && node scripts/build-widget.mjs && vite build --config src/dashboard/vite.config.ts",
     "build:widget": "node scripts/build-widget.mjs",
+    "build:dashboard": "vite build --config src/dashboard/vite.config.ts",
     "dev": "tsc --watch",
+    "dev:dashboard": "vite --config src/dashboard/vite.config.ts",
     "cli": "node bin/punchlist.mjs",
     "start": "node bin/punchlist.mjs",
     "test": "vitest run",
@@ -43,7 +45,7 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "test:coverage": "vitest run --coverage",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc --noEmit -p tsconfig.dashboard.json",
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint src/ tests/ --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
@@ -51,22 +53,31 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@tailwindcss/vite": "^4.2.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^3.2.4",
     "esbuild": "^0.27.4",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
     "happy-dom": "^20.8.4",
     "prettier": "^3.8.1",
+    "tailwindcss": "^4.2.1",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.57.1",
+    "vite": "^8.0.0",
     "vitest": "^3.2.4"
   },
   "dependencies": {
     "better-sqlite3": "^12.8.0",
     "express": "^5.2.1",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.1",
     "zod": "^4.3.6"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,13 +14,25 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      react-router-dom:
+        specifier: ^7.13.1
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.0.3)
+        version: 10.0.1(eslint@10.0.3(jiti@2.6.1))
+      '@tailwindcss/vite':
+        specifier: ^4.2.1
+        version: 4.2.1(vite@8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1))
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -30,33 +42,48 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4))
+        version: 3.2.4(vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.32.0))
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
       eslint:
         specifier: ^10.0.3
-        version: 10.0.3
+        version: 10.0.3(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.0.3)
+        version: 10.1.8(eslint@10.0.3(jiti@2.6.1))
       happy-dom:
         specifier: ^20.8.4
         version: 20.8.4
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.57.1
-        version: 8.57.1(eslint@10.0.3)(typescript@5.9.3)
+        version: 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.32.0)
 
 packages:
 
@@ -84,6 +111,15 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@emnapi/core@1.9.0':
+    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+
+  '@emnapi/runtime@1.9.0':
+    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -307,6 +343,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -317,9 +356,114 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@oxc-project/runtime@0.115.0':
+    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@rolldown/pluginutils@1.0.0-rc.9':
+    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -446,6 +590,99 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/node@4.2.1':
+    resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    resolution: {integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    resolution: {integrity: sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    resolution: {integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    resolution: {integrity: sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    resolution: {integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    resolution: {integrity: sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    resolution: {integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    resolution: {integrity: sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.1':
+    resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.1':
+    resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -487,6 +724,14 @@ packages:
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
@@ -558,6 +803,19 @@ packages:
   '@typescript-eslint/visitor-keys@8.57.1':
     resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -721,9 +979,16 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -779,6 +1044,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -965,6 +1234,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   happy-dom@20.8.4:
     resolution: {integrity: sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ==}
     engines: {node: '>=20.0.0'}
@@ -1054,6 +1326,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1075,6 +1351,146 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.31.1:
+    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.31.1:
+    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.31.1:
+    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.31.1:
+    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.31.1:
+    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.31.1:
+    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.31.1:
+    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.31.1:
+    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1265,9 +1681,40 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-router-dom@7.13.1:
+    resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.13.1:
+    resolution: {integrity: sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  rolldown@1.0.0-rc.9:
+    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -1284,6 +1731,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -1296,6 +1746,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1381,6 +1834,13 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tailwindcss@4.2.1:
+    resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
+
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -1423,6 +1883,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -1493,6 +1956,49 @@ packages:
       less:
         optional: true
       lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.0:
+    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.31
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
         optional: true
       sass:
         optional: true
@@ -1607,6 +2113,22 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@emnapi/core@1.9.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
@@ -1685,9 +2207,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.3)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.3(jiti@2.6.1))':
     dependencies:
-      eslint: 10.0.3
+      eslint: 10.0.3(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1708,9 +2230,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.0.3)':
+  '@eslint/js@10.0.1(eslint@10.0.3(jiti@2.6.1))':
     optionalDependencies:
-      eslint: 10.0.3
+      eslint: 10.0.3(jiti@2.6.1)
 
   '@eslint/object-schema@3.0.3': {}
 
@@ -1746,6 +2268,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -1755,8 +2282,70 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/runtime@0.115.0': {}
+
+  '@oxc-project/types@0.115.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -1833,6 +2422,79 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@tailwindcss/node@4.2.1':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.1
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-x64': 4.2.1
+      '@tailwindcss/oxide-freebsd-x64': 4.2.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
+
+  '@tailwindcss/vite@4.2.1(vite@8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1))':
+    dependencies:
+      '@tailwindcss/node': 4.2.1
+      '@tailwindcss/oxide': 4.2.1
+      tailwindcss: 4.2.1
+      vite: 8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1)
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 20.19.37
@@ -1882,6 +2544,14 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 20.19.37
@@ -1897,15 +2567,15 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
-  '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.1(eslint@10.0.3)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/type-utils': 8.57.1(eslint@10.0.3)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.0.3)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.1
-      eslint: 10.0.3
+      eslint: 10.0.3(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -1913,14 +2583,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.1(eslint@10.0.3)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.1
       debug: 4.4.3
-      eslint: 10.0.3
+      eslint: 10.0.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1943,13 +2613,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.57.1(eslint@10.0.3)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.0.3)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.0.3
+      eslint: 10.0.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -1972,13 +2642,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.1(eslint@10.0.3)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      eslint: 10.0.3
+      eslint: 10.0.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1988,7 +2658,12 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1)
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2003,7 +2678,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)
+      vitest: 3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2015,13 +2690,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.37))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.37)
+      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2173,11 +2848,15 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -2216,6 +2895,11 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
 
   entities@7.0.1: {}
 
@@ -2262,9 +2946,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.0.3):
+  eslint-config-prettier@10.1.8(eslint@10.0.3(jiti@2.6.1)):
     dependencies:
-      eslint: 10.0.3
+      eslint: 10.0.3(jiti@2.6.1)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -2277,9 +2961,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.0.3:
+  eslint@10.0.3(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.3
       '@eslint/config-helpers': 0.5.3
@@ -2309,6 +2993,8 @@ snapshots:
       minimatch: 10.2.4
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2463,6 +3149,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   happy-dom@20.8.4:
     dependencies:
       '@types/node': 20.19.37
@@ -2550,6 +3238,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jiti@2.6.1: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -2568,6 +3258,104 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-android-arm64@1.31.1:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.31.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.31.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.31.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.31.1
+      lightningcss-darwin-arm64: 1.31.1
+      lightningcss-darwin-x64: 1.31.1
+      lightningcss-freebsd-x64: 1.31.1
+      lightningcss-linux-arm-gnueabihf: 1.31.1
+      lightningcss-linux-arm64-gnu: 1.31.1
+      lightningcss-linux-arm64-musl: 1.31.1
+      lightningcss-linux-x64-gnu: 1.31.1
+      lightningcss-linux-x64-musl: 1.31.1
+      lightningcss-win32-arm64-msvc: 1.31.1
+      lightningcss-win32-x64-msvc: 1.31.1
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   locate-path@6.0.0:
     dependencies:
@@ -2740,11 +3528,53 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-router-dom@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  react@19.2.4: {}
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  rolldown@1.0.0-rc.9:
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.9
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
 
   rollup@4.59.0:
     dependencies:
@@ -2791,6 +3621,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.27.0: {}
+
   semver@7.7.4: {}
 
   send@1.2.1:
@@ -2817,6 +3649,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 
@@ -2908,6 +3742,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tailwindcss@4.2.1: {}
+
+  tapable@2.3.0: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -2950,6 +3788,9 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  tslib@2.8.1:
+    optional: true
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -2964,13 +3805,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.57.1(eslint@10.0.3)(typescript@5.9.3):
+  typescript-eslint@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.57.1(eslint@10.0.3)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.0.3)(typescript@5.9.3)
-      eslint: 10.0.3
+      '@typescript-eslint/utils': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.0.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2989,13 +3830,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.37):
+  vite-node@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.19.37)
+      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3010,7 +3851,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@20.19.37):
+  vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3021,12 +3862,28 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.37
       fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
 
-  vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4):
+  vite@8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1):
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.37
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.37))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3044,8 +3901,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@20.19.37)
-      vite-node: 3.2.4(@types/node@20.19.37)
+      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1,21 +1,10 @@
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
-import { loadConfig } from '../../shared/config.js';
-import { DEFAULT_PORT, CONFIG_FILENAME } from '../../shared/constants.js';
+import { DEFAULT_PORT } from '../../shared/constants.js';
 import { GitHubIssueAdapter } from '../../adapters/issues/index.js';
 import { createApp } from '../../server/app.js';
+import { initAdapters } from '../helpers.js';
 
 export async function serveCommand(): Promise<void> {
-  const cwd = process.cwd();
-  const configPath = join(cwd, CONFIG_FILENAME);
-
-  if (!existsSync(configPath)) {
-    console.error(`\n  No ${CONFIG_FILENAME} found.`);
-    console.error('  Run "punchlist-qa init" first.\n');
-    process.exit(1);
-  }
-
-  const config = loadConfig(cwd);
+  const { config, storage, auth } = await initAdapters();
 
   if (!config.secrets.githubToken) {
     console.error('\n  Missing PUNCHLIST_GITHUB_TOKEN. Set it in .env or environment.\n');
@@ -29,6 +18,9 @@ export async function serveCommand(): Promise<void> {
 
   const app = createApp({
     issueAdapter,
+    storageAdapter: storage,
+    authAdapter: auth,
+    config,
     corsDomains: config.widget.corsDomains,
   });
 
@@ -37,7 +29,8 @@ export async function serveCommand(): Promise<void> {
     console.log(`  Project: ${config.projectName}`);
     console.log(`  Port: ${DEFAULT_PORT}`);
     console.log(`  CORS: ${config.widget.corsDomains.join(', ')}`);
-    console.log(`\n  Widget: http://localhost:${DEFAULT_PORT}/widget.js`);
-    console.log(`  API:    http://localhost:${DEFAULT_PORT}/api/support/ticket\n`);
+    console.log(`\n  Dashboard: http://localhost:${DEFAULT_PORT}/`);
+    console.log(`  Widget:    http://localhost:${DEFAULT_PORT}/widget.js`);
+    console.log(`  API:       http://localhost:${DEFAULT_PORT}/api/\n`);
   });
 }

--- a/src/dashboard/App.tsx
+++ b/src/dashboard/App.tsx
@@ -1,0 +1,42 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { AuthProvider, useAuth } from './hooks/useAuth';
+import { Layout } from './components/Layout';
+import { LoginPage } from './components/LoginPage';
+import { TestingPage } from './pages/TestingPage';
+import { HistoryPage } from './pages/HistoryPage';
+
+function ProtectedRoutes() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <LoginPage />;
+  }
+
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<TestingPage />} />
+        <Route path="/history" element={<HistoryPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </Layout>
+  );
+}
+
+export function App() {
+  return (
+    <BrowserRouter>
+      <AuthProvider>
+        <ProtectedRoutes />
+      </AuthProvider>
+    </BrowserRouter>
+  );
+}

--- a/src/dashboard/api/client.ts
+++ b/src/dashboard/api/client.ts
@@ -1,0 +1,133 @@
+const BASE = '/api';
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+
+  if (res.status === 401) {
+    throw new Error('UNAUTHENTICATED');
+  }
+
+  const json = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.error || `Request failed: ${res.status}`);
+  }
+
+  return json;
+}
+
+// Auth
+export function login(token: string) {
+  return request('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ token }),
+  });
+}
+
+export function logout() {
+  return request('/auth/logout', { method: 'POST' });
+}
+
+// Users
+export function getMe() {
+  return request<{ success: boolean; data: { email: string; name: string; role: string } }>(
+    '/users/me',
+  );
+}
+
+// Config
+export function getConfig() {
+  return request<{
+    success: boolean;
+    data: {
+      projectName: string;
+      testCases: Array<{
+        id: string;
+        title: string;
+        category: string;
+        priority: string;
+        instructions: string;
+        expectedResult: string;
+      }>;
+      categories: Array<{ id: string; label: string; description?: string }>;
+    };
+  }>('/config');
+}
+
+// Rounds
+export function listRounds() {
+  return request<{ success: boolean; data: Array<Record<string, unknown>> }>('/rounds');
+}
+
+export function createRound(input: { name: string; description?: string }) {
+  return request<{ success: boolean; data: Record<string, unknown> }>('/rounds', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
+export function updateRound(id: string, input: Record<string, unknown>) {
+  return request<{ success: boolean; data: Record<string, unknown> }>(`/rounds/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(input),
+  });
+}
+
+// Results
+export function listResults(roundId: string) {
+  return request<{ success: boolean; data: Array<Record<string, unknown>> }>(
+    `/rounds/${roundId}/results`,
+  );
+}
+
+export function submitResult(
+  roundId: string,
+  input: {
+    testId: string;
+    status: string;
+    description?: string;
+    severity?: string;
+    commitHash?: string;
+  },
+) {
+  return request<{ success: boolean; data: Record<string, unknown> }>(
+    `/rounds/${roundId}/results`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export function deleteResult(roundId: string, testId: string) {
+  return request<{ success: boolean; deleted: number }>(`/rounds/${roundId}/results/${testId}`, {
+    method: 'DELETE',
+  });
+}
+
+// Issues
+export function createIssue(opts: Record<string, unknown>) {
+  return request<{
+    success: boolean;
+    data: { url: string; id: string; number: number };
+  }>('/issues', {
+    method: 'POST',
+    body: JSON.stringify(opts),
+  });
+}
+
+export function getOpenIssue(testId: string) {
+  return request<{
+    success: boolean;
+    data: { url: string; number: number; title: string } | null;
+  }>(`/issues/open/${testId}`);
+}
+
+// Commit
+export function getCommitSha() {
+  return request<{ success: boolean; data: { sha: string } }>('/commit');
+}

--- a/src/dashboard/app.css
+++ b/src/dashboard/app.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/src/dashboard/components/Layout.tsx
+++ b/src/dashboard/components/Layout.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export function Layout({ children }: { children: ReactNode }) {
+  const { user, logout } = useAuth();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <nav className="bg-white border-b border-gray-200 px-4 py-3">
+        <div className="max-w-7xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-6">
+            <span className="font-semibold text-gray-900">Punchlist QA</span>
+            <div className="flex gap-4">
+              <NavLink
+                to="/"
+                end
+                className={({ isActive }) =>
+                  `text-sm ${isActive ? 'text-blue-600 font-medium' : 'text-gray-600 hover:text-gray-900'}`
+                }
+              >
+                Testing
+              </NavLink>
+              <NavLink
+                to="/history"
+                className={({ isActive }) =>
+                  `text-sm ${isActive ? 'text-blue-600 font-medium' : 'text-gray-600 hover:text-gray-900'}`
+                }
+              >
+                History
+              </NavLink>
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-gray-600">{user?.name}</span>
+            <button
+              onClick={() => logout()}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+      </nav>
+      <main className="max-w-7xl mx-auto px-4 py-6">{children}</main>
+    </div>
+  );
+}

--- a/src/dashboard/components/LoginPage.tsx
+++ b/src/dashboard/components/LoginPage.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
+
+export function LoginPage() {
+  const { login } = useAuth();
+  const [token, setToken] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      await login(token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 w-full max-w-md">
+        <h1 className="text-xl font-semibold text-gray-900 mb-6">Punchlist QA</h1>
+        <form onSubmit={handleSubmit}>
+          <label htmlFor="token" className="block text-sm font-medium text-gray-700 mb-2">
+            Invite Token
+          </label>
+          <input
+            id="token"
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="Paste your invite token"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            disabled={loading}
+          />
+          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading || !token.trim()}
+            className="mt-4 w-full bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Signing in...' : 'Sign In'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/dashboard/hooks/useAuth.tsx
+++ b/src/dashboard/hooks/useAuth.tsx
@@ -1,0 +1,54 @@
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import * as api from '../api/client';
+
+interface UserInfo {
+  email: string;
+  name: string;
+  role: string;
+}
+
+interface AuthContextValue {
+  user: UserInfo | null;
+  loading: boolean;
+  login: (token: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<UserInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .getMe()
+      .then((res) => setUser(res.data))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const login = useCallback(async (token: string) => {
+    await api.login(token);
+    const res = await api.getMe();
+    setUser(res.data);
+  }, []);
+
+  const logout = useCallback(async () => {
+    await api.logout();
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, logout }}>{children}</AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}

--- a/src/dashboard/hooks/useConfig.ts
+++ b/src/dashboard/hooks/useConfig.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import * as api from '../api/client';
+
+interface ConfigData {
+  projectName: string;
+  testCases: Array<{
+    id: string;
+    title: string;
+    category: string;
+    priority: string;
+    instructions: string;
+    expectedResult: string;
+  }>;
+  categories: Array<{ id: string; label: string; description?: string }>;
+}
+
+export function useConfig() {
+  const [config, setConfig] = useState<ConfigData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .getConfig()
+      .then((res) => setConfig(res.data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { config, loading, error };
+}

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Punchlist QA Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/dashboard/main.tsx
+++ b/src/dashboard/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './app.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/dashboard/pages/HistoryPage.tsx
+++ b/src/dashboard/pages/HistoryPage.tsx
@@ -1,0 +1,8 @@
+export function HistoryPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-gray-900 mb-4">History</h1>
+      <p className="text-gray-500">Round history and details coming in the next update.</p>
+    </div>
+  );
+}

--- a/src/dashboard/pages/TestingPage.tsx
+++ b/src/dashboard/pages/TestingPage.tsx
@@ -1,0 +1,8 @@
+export function TestingPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-gray-900 mb-4">Testing</h1>
+      <p className="text-gray-500">Test execution UI coming in the next update.</p>
+    </div>
+  );
+}

--- a/src/dashboard/vite.config.ts
+++ b/src/dashboard/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  root: 'src/dashboard',
+  build: {
+    outDir: '../../dist/dashboard',
+    emptyOutDir: true,
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:4747',
+    },
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
   createSupportTicketOptsSchema,
   labelDefSchema,
   supportTicketRequestSchema,
+  loginRequestSchema,
 } from './shared/schemas.js';
 export { ConfigFetcher, ConfigFetcherError } from './shared/config-fetcher.js';
 export type { ConfigFetcherOpts } from './shared/config-fetcher.js';
@@ -49,6 +50,7 @@ export type {
   CreateSupportTicketOpts,
   LabelDef,
   SupportTicketRequest,
+  LoginRequest,
 } from './shared/types.js';
 export { SqliteAdapter } from './adapters/storage/index.js';
 export type { StorageAdapter } from './adapters/storage/types.js';

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2,12 +2,27 @@ import express from 'express';
 import type { Express } from 'express';
 import { corsMiddleware } from './middleware/cors.js';
 import { errorHandler } from './middleware/error-handler.js';
+import { requireAuth } from './middleware/auth.js';
 import { supportRouter } from './routes/support.js';
 import { widgetServeRouter } from './routes/widget-serve.js';
+import { authRouter } from './routes/auth.js';
+import { roundsRouter } from './routes/rounds.js';
+import { resultsRouter } from './routes/results.js';
+import { configRouter } from './routes/config.js';
+import { issuesRouter } from './routes/issues-api.js';
+import { commitRouter } from './routes/commit.js';
+import { usersRouter } from './routes/users-api.js';
+import { dashboardRouter } from './routes/dashboard.js';
 import type { IssueAdapter } from '../adapters/issues/types.js';
+import type { StorageAdapter } from '../adapters/storage/types.js';
+import type { AuthAdapter } from '../adapters/auth/types.js';
+import type { PunchlistConfig } from '../shared/types.js';
 
 export interface AppDependencies {
   issueAdapter: IssueAdapter;
+  storageAdapter?: StorageAdapter;
+  authAdapter?: AuthAdapter;
+  config?: PunchlistConfig;
   corsDomains: string[];
 }
 
@@ -24,12 +39,46 @@ export function createApp(deps: AppDependencies): Express {
   // CORS middleware on API routes only
   app.use('/api/support', corsMiddleware(deps.corsDomains));
 
-  // Routes
+  // Public routes (no auth required)
   app.use('/api/support', supportRouter(deps.issueAdapter));
+  app.use('/api/auth', authRouter(deps.authAdapter ?? createNoopAuthAdapter()));
+
+  // Protected routes (require valid session)
+  if (deps.storageAdapter && deps.authAdapter && deps.config) {
+    const auth = requireAuth(deps.authAdapter);
+
+    app.use('/api/rounds', auth, roundsRouter(deps.storageAdapter));
+    app.use('/api/rounds', auth, resultsRouter(deps.storageAdapter));
+    app.use('/api/config', auth, configRouter(deps.config));
+    app.use('/api/issues', auth, issuesRouter(deps.issueAdapter));
+    app.use('/api/commit', auth, commitRouter());
+    app.use('/api/users', auth, usersRouter());
+  }
+
+  // Static file serving
   app.use('/', widgetServeRouter());
+  app.use('/', dashboardRouter());
 
   // Error handler (must be last)
   app.use(errorHandler);
 
   return app;
+}
+
+function createNoopAuthAdapter(): AuthAdapter {
+  const fail = (msg: string) => {
+    throw new Error(msg);
+  };
+  const asyncFail = (msg: string) => Promise.reject(new Error(msg));
+  return {
+    generateToken: () => fail('Auth not configured'),
+    validateToken: () => fail('Auth not configured'),
+    createInvite: () => asyncFail('Auth not configured'),
+    revokeAccess: () => asyncFail('Auth not configured'),
+    listUsers: () => asyncFail('Auth not configured'),
+    loginWithToken: () => asyncFail('Auth not configured'),
+    createSession: () => asyncFail('Auth not configured'),
+    validateSession: () => asyncFail('Auth not configured'),
+    destroySession: () => asyncFail('Auth not configured'),
+  };
 }

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -1,0 +1,33 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { AuthAdapter } from '../../adapters/auth/types.js';
+import type { User } from '../../shared/types.js';
+import { authenticateRequest } from '../../adapters/auth/middleware.js';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: User;
+    }
+  }
+}
+
+/**
+ * Express middleware that validates the session cookie and sets req.user.
+ * Returns 401 if no valid session is found.
+ */
+export function requireAuth(authAdapter: AuthAdapter) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const user = await authenticateRequest(authAdapter, req.headers.cookie);
+      if (!user) {
+        res.status(401).json({ success: false, error: 'Authentication required' });
+        return;
+      }
+      req.user = user;
+      next();
+    } catch {
+      res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+  };
+}

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import type { AuthAdapter } from '../../adapters/auth/types.js';
+import { loginRequestSchema } from '../../shared/schemas.js';
+import { handleLogin, handleLogout, parseCookie } from '../../adapters/auth/middleware.js';
+
+export function authRouter(authAdapter: AuthAdapter): Router {
+  const router = Router();
+
+  router.post('/login', async (req, res, next) => {
+    try {
+      const { token } = loginRequestSchema.parse(req.body);
+      const result = await handleLogin(authAdapter, token);
+
+      if ('error' in result) {
+        res.status(result.status).json({ success: false, error: result.error });
+        return;
+      }
+
+      res.setHeader('Set-Cookie', result.cookie);
+      res.status(200).json({ success: true });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/logout', async (req, res, next) => {
+    try {
+      const sessionId = parseCookie(req.headers.cookie, 'punchlist_session');
+      if (sessionId) {
+        const { cookie } = await handleLogout(authAdapter, sessionId);
+        res.setHeader('Set-Cookie', cookie);
+      }
+      res.status(200).json({ success: true });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/src/server/routes/commit.ts
+++ b/src/server/routes/commit.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { TTLCache } from '../../adapters/issues/cache.js';
+import { execSync } from 'node:child_process';
+
+function getLatestCommitSha(): string {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function commitRouter(): Router {
+  const commitCache = new TTLCache<string>(30 * 1000); // 30s TTL
+  const router = Router();
+
+  router.get('/', (_req, res) => {
+    let sha = commitCache.get('latest');
+    if (!sha) {
+      sha = getLatestCommitSha();
+      commitCache.set('latest', sha);
+    }
+    res.json({ success: true, data: { sha } });
+  });
+
+  return router;
+}

--- a/src/server/routes/config.ts
+++ b/src/server/routes/config.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import type { PunchlistConfig } from '../../shared/types.js';
+
+export function configRouter(config: PunchlistConfig): Router {
+  const router = Router();
+
+  router.get('/', (_req, res) => {
+    res.json({
+      success: true,
+      data: {
+        projectName: config.projectName,
+        testCases: config.testCases,
+        categories: config.categories,
+      },
+    });
+  });
+
+  return router;
+}

--- a/src/server/routes/dashboard.ts
+++ b/src/server/routes/dashboard.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import express from 'express';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+export function dashboardRouter(): Router {
+  const router = Router();
+
+  const dashboardDir = join(import.meta.dirname, '../../../dist/dashboard');
+
+  if (existsSync(dashboardDir)) {
+    router.use(express.static(dashboardDir));
+
+    // SPA fallback: serve index.html for unmatched routes
+    router.get('{*path}', (_req, res) => {
+      res.sendFile(join(dashboardDir, 'index.html'));
+    });
+  }
+
+  return router;
+}

--- a/src/server/routes/issues-api.ts
+++ b/src/server/routes/issues-api.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import type { IssueAdapter } from '../../adapters/issues/types.js';
+import { createQAFailureOptsSchema } from '../../shared/schemas.js';
+
+export function issuesRouter(issueAdapter: IssueAdapter): Router {
+  const router = Router();
+
+  router.post('/', async (req, res, next) => {
+    try {
+      const opts = createQAFailureOptsSchema.parse(req.body);
+      const issue = await issueAdapter.createQAFailureIssue(opts);
+      res.status(201).json({ success: true, data: issue });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/open/:testId', async (req, res, next) => {
+    try {
+      const issue = await issueAdapter.getOpenIssueForTest(req.params.testId);
+      res.json({ success: true, data: issue });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/src/server/routes/results.ts
+++ b/src/server/routes/results.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import type { StorageAdapter } from '../../adapters/storage/types.js';
+import { submitResultInputSchema } from '../../shared/schemas.js';
+
+export function resultsRouter(storageAdapter: StorageAdapter): Router {
+  const router = Router();
+
+  router.get('/:roundId/results', async (req, res, next) => {
+    try {
+      const results = await storageAdapter.listResults(req.params.roundId);
+      res.json({ success: true, data: results });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/:roundId/results', async (req, res, next) => {
+    try {
+      const body = submitResultInputSchema.parse(req.body);
+      const input = {
+        ...body,
+        testerName: req.user!.name,
+        testerEmail: req.user!.email,
+      };
+      const result = await storageAdapter.submitResult(req.params.roundId, input);
+      res.status(201).json({ success: true, data: result });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/:roundId/results/:testId', async (req, res, next) => {
+    try {
+      const count = await storageAdapter.deleteResultsByTestIds(req.params.roundId, [
+        req.params.testId,
+      ]);
+      res.json({ success: true, deleted: count });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/src/server/routes/rounds.ts
+++ b/src/server/routes/rounds.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import type { StorageAdapter } from '../../adapters/storage/types.js';
+import { createRoundInputSchema, updateRoundInputSchema } from '../../shared/schemas.js';
+
+export function roundsRouter(storageAdapter: StorageAdapter): Router {
+  const router = Router();
+
+  router.get('/', async (_req, res, next) => {
+    try {
+      const rounds = await storageAdapter.listRounds();
+      res.json({ success: true, data: rounds });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/', async (req, res, next) => {
+    try {
+      const body = createRoundInputSchema.parse(req.body);
+      const input = {
+        ...body,
+        createdByEmail: req.user!.email,
+        createdByName: req.user!.name,
+      };
+      const round = await storageAdapter.createRound(input);
+      res.status(201).json({ success: true, data: round });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.put('/:id', async (req, res, next) => {
+    try {
+      const input = updateRoundInputSchema.parse(req.body);
+      const round = await storageAdapter.updateRound(req.params.id, input);
+      res.json({ success: true, data: round });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/src/server/routes/users-api.ts
+++ b/src/server/routes/users-api.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+
+export function usersRouter(): Router {
+  const router = Router();
+
+  router.get('/me', (req, res) => {
+    const { id, email, name, role } = req.user!;
+    res.json({ success: true, data: { id, email, name, role } });
+  });
+
+  return router;
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -192,6 +192,12 @@ export const createSupportTicketOptsSchema = z.object({
   customContext: z.record(z.string(), z.string()).optional(),
 });
 
+// --- Auth request schemas ---
+
+export const loginRequestSchema = z.object({
+  token: z.string().min(1, 'Token is required'),
+});
+
 // --- Widget request schema (incoming from browser widget → server) ---
 
 export const supportTicketRequestSchema = z.object({
@@ -336,3 +342,4 @@ export type CreateQAFailureOpts = z.infer<typeof createQAFailureOptsSchema>;
 export type CreateSupportTicketOpts = z.infer<typeof createSupportTicketOptsSchema>;
 export type LabelDef = z.infer<typeof labelDefSchema>;
 export type SupportTicketRequest = z.infer<typeof supportTicketRequestSchema>;
+export type LoginRequest = z.infer<typeof loginRequestSchema>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,4 +33,5 @@ export type {
   CreateSupportTicketOpts,
   LabelDef,
   SupportTicketRequest,
+  LoginRequest,
 } from './schemas.js';

--- a/tests/unit/server/auth-route.test.ts
+++ b/tests/unit/server/auth-route.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import type { AuthAdapter } from '../../../src/adapters/auth/types.js';
+import { authRouter } from '../../../src/server/routes/auth.js';
+import { errorHandler } from '../../../src/server/middleware/error-handler.js';
+import { RevokedUserError } from '../../../src/adapters/auth/errors.js';
+
+function createMockAuthAdapter(overrides: Partial<AuthAdapter> = {}): AuthAdapter {
+  return {
+    generateToken: vi.fn(),
+    validateToken: vi.fn(),
+    createInvite: vi.fn(),
+    revokeAccess: vi.fn(),
+    listUsers: vi.fn(),
+    loginWithToken: vi.fn().mockResolvedValue('session-123'),
+    createSession: vi.fn(),
+    validateSession: vi.fn(),
+    destroySession: vi.fn(),
+    ...overrides,
+  } as AuthAdapter;
+}
+
+function makeRequest(
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : undefined;
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: {
+          ...(data
+            ? {
+                'Content-Type': 'application/json',
+                'Content-Length': String(Buffer.byteLength(data)),
+              }
+            : {}),
+          ...headers,
+        },
+      },
+      (res) => {
+        let resBody = '';
+        res.on('data', (chunk) => (resBody += chunk));
+        res.on('end', () => {
+          try {
+            resolve({
+              status: res.statusCode!,
+              headers: res.headers,
+              body: JSON.parse(resBody),
+            });
+          } catch {
+            resolve({
+              status: res.statusCode!,
+              headers: res.headers,
+              body: { raw: resBody },
+            });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+describe('auth routes', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  function createServer(adapter: AuthAdapter) {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/auth', authRouter(adapter));
+    app.use(errorHandler);
+    server = app.listen(0);
+    return server;
+  }
+
+  describe('POST /api/auth/login', () => {
+    it('returns 200 with Set-Cookie on valid token', async () => {
+      const adapter = createMockAuthAdapter();
+      createServer(adapter);
+
+      const res = await makeRequest(server, 'POST', '/api/auth/login', {
+        token: 'valid-token',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      const setCookie = res.headers['set-cookie'];
+      expect(setCookie).toBeDefined();
+      expect(String(setCookie)).toContain('punchlist_session=session-123');
+    });
+
+    it('returns 400 for missing token', async () => {
+      const adapter = createMockAuthAdapter();
+      createServer(adapter);
+
+      const res = await makeRequest(server, 'POST', '/api/auth/login', {});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('returns 401 for invalid token', async () => {
+      const adapter = createMockAuthAdapter({
+        loginWithToken: vi.fn().mockRejectedValue(new Error('Invalid token')),
+      });
+      createServer(adapter);
+
+      const res = await makeRequest(server, 'POST', '/api/auth/login', {
+        token: 'bad-token',
+      });
+
+      expect(res.status).toBe(401);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Invalid token');
+    });
+
+    it('returns 403 for revoked user', async () => {
+      const adapter = createMockAuthAdapter({
+        loginWithToken: vi
+          .fn()
+          .mockRejectedValue(new RevokedUserError('revoked@example.com')),
+      });
+      createServer(adapter);
+
+      const res = await makeRequest(server, 'POST', '/api/auth/login', {
+        token: 'revoked-token',
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('POST /api/auth/logout', () => {
+    it('clears session cookie', async () => {
+      const adapter = createMockAuthAdapter();
+      createServer(adapter);
+
+      const res = await makeRequest(server, 'POST', '/api/auth/logout', undefined, {
+        Cookie: 'punchlist_session=session-123',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      const setCookie = String(res.headers['set-cookie']);
+      expect(setCookie).toContain('Max-Age=0');
+      expect(adapter.destroySession).toHaveBeenCalledWith('session-123');
+    });
+
+    it('returns 200 even without cookie', async () => {
+      const adapter = createMockAuthAdapter();
+      createServer(adapter);
+
+      const res = await makeRequest(server, 'POST', '/api/auth/logout');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+});

--- a/tests/unit/server/commit-route.test.ts
+++ b/tests/unit/server/commit-route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { commitRouter } from '../../../src/server/routes/commit.js';
+
+function makeRequest(
+  server: http.Server,
+  path: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path, method: 'GET' },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(body) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: body } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('commit route', () => {
+  let server: http.Server;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('GET /api/commit returns a commit SHA', async () => {
+    vi.useRealTimers(); // execSync needs real timers
+    const app = express();
+    app.use('/api/commit', commitRouter());
+    server = app.listen(0);
+
+    const res = await makeRequest(server, '/api/commit');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const data = res.body.data as Record<string, unknown>;
+    expect(typeof data.sha).toBe('string');
+    expect((data.sha as string).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/server/config-route.test.ts
+++ b/tests/unit/server/config-route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { configRouter } from '../../../src/server/routes/config.js';
+import type { PunchlistConfig } from '../../../src/shared/types.js';
+
+const mockConfig: PunchlistConfig = {
+  projectName: 'Test Project',
+  issueTracker: { type: 'github', repo: 'owner/repo' },
+  storage: { type: 'sqlite', path: 'data/punchlist.db' },
+  auth: { type: 'token' },
+  widget: {
+    position: 'bottom-right',
+    theme: 'light',
+    corsDomains: [],
+    categories: [],
+  },
+  aiTool: 'none',
+  categories: [{ id: 'auth', label: 'Authentication' }],
+  testCases: [
+    {
+      id: 'auth-001',
+      title: 'Login works',
+      category: 'auth',
+      priority: 'high',
+      instructions: 'Try to login',
+      expectedResult: 'Login succeeds',
+    },
+  ],
+  testers: [],
+};
+
+function makeRequest(
+  server: http.Server,
+  path: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path, method: 'GET' },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(body) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: body } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('config route', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('GET /api/config returns project config', async () => {
+    const app = express();
+    app.use('/api/config', configRouter(mockConfig));
+    server = app.listen(0);
+
+    const res = await makeRequest(server, '/api/config');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.projectName).toBe('Test Project');
+    expect(Array.isArray(data.testCases)).toBe(true);
+    expect(Array.isArray(data.categories)).toBe(true);
+  });
+});

--- a/tests/unit/server/require-auth.test.ts
+++ b/tests/unit/server/require-auth.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import type { AuthAdapter } from '../../../src/adapters/auth/types.js';
+import { requireAuth } from '../../../src/server/middleware/auth.js';
+
+function createMockAuthAdapter(overrides: Partial<AuthAdapter> = {}): AuthAdapter {
+  return {
+    generateToken: vi.fn(),
+    validateToken: vi.fn(),
+    createInvite: vi.fn(),
+    revokeAccess: vi.fn(),
+    listUsers: vi.fn(),
+    loginWithToken: vi.fn(),
+    createSession: vi.fn(),
+    validateSession: vi.fn().mockResolvedValue(null),
+    destroySession: vi.fn(),
+    ...overrides,
+  } as AuthAdapter;
+}
+
+function makeRequest(
+  server: http.Server,
+  method: string,
+  path: string,
+  headers?: Record<string, string>,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: headers ?? {},
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(body) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: body } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('requireAuth middleware', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('returns 401 when no cookie is present', async () => {
+    const auth = createMockAuthAdapter();
+    const app = express();
+    app.use(requireAuth(auth));
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'GET', '/test');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Authentication required');
+  });
+
+  it('returns 401 when session is invalid', async () => {
+    const auth = createMockAuthAdapter({
+      validateSession: vi.fn().mockResolvedValue(null),
+    });
+    const app = express();
+    app.use(requireAuth(auth));
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'GET', '/test', {
+      Cookie: 'punchlist_session=invalid-session-id',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('passes through and sets req.user with valid session', async () => {
+    const mockUser = {
+      id: 'u1',
+      email: 'tester@example.com',
+      name: 'Tester',
+      tokenHash: 'hash',
+      role: 'tester' as const,
+      invitedBy: 'admin@example.com',
+      revoked: false,
+      createdAt: new Date().toISOString(),
+    };
+
+    const auth = createMockAuthAdapter({
+      validateSession: vi.fn().mockResolvedValue(mockUser),
+    });
+
+    const app = express();
+    app.use(requireAuth(auth));
+    app.get('/test', (req, res) => {
+      res.json({ ok: true, user: req.user });
+    });
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'GET', '/test', {
+      Cookie: 'punchlist_session=valid-session-id',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect((res.body.user as Record<string, unknown>).email).toBe('tester@example.com');
+  });
+
+  it('returns 401 when validateSession throws', async () => {
+    const auth = createMockAuthAdapter({
+      validateSession: vi.fn().mockRejectedValue(new Error('DB error')),
+    });
+    const app = express();
+    app.use(requireAuth(auth));
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'GET', '/test', {
+      Cookie: 'punchlist_session=some-id',
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/unit/server/results-route.test.ts
+++ b/tests/unit/server/results-route.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import type { Request, Response, NextFunction } from 'express';
+import type { StorageAdapter } from '../../../src/adapters/storage/types.js';
+import { resultsRouter } from '../../../src/server/routes/results.js';
+import { errorHandler } from '../../../src/server/middleware/error-handler.js';
+
+const mockUser = {
+  id: 'u1',
+  email: 'tester@example.com',
+  name: 'Tester',
+  tokenHash: 'hash',
+  role: 'tester' as const,
+  invitedBy: 'admin@example.com',
+  revoked: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+const mockResult = {
+  id: 'result-1',
+  roundId: 'round-1',
+  testId: 'auth-001',
+  status: 'pass' as const,
+  testerName: 'Tester',
+  testerEmail: 'tester@example.com',
+  description: null,
+  severity: null,
+  commitHash: 'abc123',
+  issueUrl: null,
+  issueNumber: null,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+function createMockStorage(overrides: Partial<StorageAdapter> = {}): StorageAdapter {
+  return {
+    initialize: vi.fn(),
+    close: vi.fn(),
+    createRound: vi.fn(),
+    listRounds: vi.fn(),
+    getRound: vi.fn(),
+    updateRound: vi.fn(),
+    submitResult: vi.fn().mockResolvedValue(mockResult),
+    listResults: vi.fn().mockResolvedValue([mockResult]),
+    deleteResult: vi.fn(),
+    deleteResultsByTestIds: vi.fn().mockResolvedValue(1),
+    updateResultIssue: vi.fn(),
+    createUser: vi.fn(),
+    listUsers: vi.fn(),
+    getUserByEmail: vi.fn(),
+    getUserByTokenHash: vi.fn(),
+    revokeUser: vi.fn(),
+    getConfig: vi.fn(),
+    setConfig: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(),
+    getSessionWithUser: vi.fn(),
+    deleteSession: vi.fn(),
+    deleteExpiredSessions: vi.fn(),
+    ...overrides,
+  };
+}
+
+function injectUser(req: Request, _res: Response, next: NextFunction) {
+  req.user = mockUser;
+  next();
+}
+
+function makeRequest(
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : undefined;
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: data
+          ? {
+              'Content-Type': 'application/json',
+              'Content-Length': String(Buffer.byteLength(data)),
+            }
+          : {},
+      },
+      (res) => {
+        let resBody = '';
+        res.on('data', (chunk) => (resBody += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(resBody) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: resBody } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+describe('results routes', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  function createServer(storage: StorageAdapter) {
+    const app = express();
+    app.use(express.json());
+    app.use(injectUser);
+    app.use('/api/rounds', resultsRouter(storage));
+    app.use(errorHandler);
+    server = app.listen(0);
+    return server;
+  }
+
+  it('GET /api/rounds/:roundId/results returns results', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'GET', '/api/rounds/round-1/results');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(storage.listResults).toHaveBeenCalledWith('round-1');
+  });
+
+  it('POST /api/rounds/:roundId/results submits with session identity', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'POST', '/api/rounds/round-1/results', {
+      testId: 'auth-001',
+      status: 'pass',
+      testerName: 'Ignored',
+      testerEmail: 'ignored@example.com',
+      commitHash: 'abc123',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    // Verify session identity is used, not body values
+    expect(storage.submitResult).toHaveBeenCalledWith(
+      'round-1',
+      expect.objectContaining({
+        testId: 'auth-001',
+        testerName: 'Tester',
+        testerEmail: 'tester@example.com',
+      }),
+    );
+  });
+
+  it('POST /api/rounds/:roundId/results returns 400 for invalid input', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'POST', '/api/rounds/round-1/results', {});
+    expect(res.status).toBe(400);
+  });
+
+  it('DELETE /api/rounds/:roundId/results/:testId deletes result', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'DELETE', '/api/rounds/round-1/results/auth-001');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.deleted).toBe(1);
+    expect(storage.deleteResultsByTestIds).toHaveBeenCalledWith('round-1', ['auth-001']);
+  });
+});

--- a/tests/unit/server/rounds-route.test.ts
+++ b/tests/unit/server/rounds-route.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import type { Request, Response, NextFunction } from 'express';
+import type { StorageAdapter } from '../../../src/adapters/storage/types.js';
+import { roundsRouter } from '../../../src/server/routes/rounds.js';
+import { errorHandler } from '../../../src/server/middleware/error-handler.js';
+
+const mockUser = {
+  id: 'u1',
+  email: 'admin@example.com',
+  name: 'Admin',
+  tokenHash: 'hash',
+  role: 'admin' as const,
+  invitedBy: 'system@example.com',
+  revoked: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+const mockRound = {
+  id: 'round-1',
+  name: 'Sprint 1',
+  description: null,
+  status: 'active' as const,
+  createdByEmail: 'admin@example.com',
+  createdByName: 'Admin',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  completedAt: null,
+};
+
+function createMockStorage(overrides: Partial<StorageAdapter> = {}): StorageAdapter {
+  return {
+    initialize: vi.fn(),
+    close: vi.fn(),
+    createRound: vi.fn().mockResolvedValue(mockRound),
+    listRounds: vi.fn().mockResolvedValue([mockRound]),
+    getRound: vi.fn().mockResolvedValue(mockRound),
+    updateRound: vi.fn().mockResolvedValue({ ...mockRound, name: 'Updated' }),
+    submitResult: vi.fn(),
+    listResults: vi.fn(),
+    deleteResult: vi.fn(),
+    deleteResultsByTestIds: vi.fn(),
+    updateResultIssue: vi.fn(),
+    createUser: vi.fn(),
+    listUsers: vi.fn(),
+    getUserByEmail: vi.fn(),
+    getUserByTokenHash: vi.fn(),
+    revokeUser: vi.fn(),
+    getConfig: vi.fn(),
+    setConfig: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(),
+    getSessionWithUser: vi.fn(),
+    deleteSession: vi.fn(),
+    deleteExpiredSessions: vi.fn(),
+    ...overrides,
+  };
+}
+
+function injectUser(req: Request, _res: Response, next: NextFunction) {
+  req.user = mockUser;
+  next();
+}
+
+function makeRequest(
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : undefined;
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: data
+          ? {
+              'Content-Type': 'application/json',
+              'Content-Length': String(Buffer.byteLength(data)),
+            }
+          : {},
+      },
+      (res) => {
+        let resBody = '';
+        res.on('data', (chunk) => (resBody += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(resBody) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: resBody } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+describe('rounds routes', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  function createServer(storage: StorageAdapter) {
+    const app = express();
+    app.use(express.json());
+    app.use(injectUser);
+    app.use('/api/rounds', roundsRouter(storage));
+    app.use(errorHandler);
+    server = app.listen(0);
+    return server;
+  }
+
+  it('GET /api/rounds returns list of rounds', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'GET', '/api/rounds');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('POST /api/rounds creates a round with identity from session', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'POST', '/api/rounds', {
+      name: 'Sprint 1',
+      createdByEmail: 'ignored@example.com',
+      createdByName: 'Ignored',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    // Verify session identity is used, not body values
+    expect(storage.createRound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Sprint 1',
+        createdByEmail: 'admin@example.com',
+        createdByName: 'Admin',
+      }),
+    );
+  });
+
+  it('POST /api/rounds returns 400 for invalid input', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'POST', '/api/rounds', {});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('PUT /api/rounds/:id updates a round', async () => {
+    const storage = createMockStorage();
+    createServer(storage);
+
+    const res = await makeRequest(server, 'PUT', '/api/rounds/round-1', {
+      name: 'Updated',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(storage.updateRound).toHaveBeenCalledWith('round-1', { name: 'Updated' });
+  });
+});

--- a/tests/unit/server/users-route.test.ts
+++ b/tests/unit/server/users-route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import type { Request, Response, NextFunction } from 'express';
+import { usersRouter } from '../../../src/server/routes/users-api.js';
+
+const mockUser = {
+  id: 'u1',
+  email: 'tester@example.com',
+  name: 'Tester',
+  tokenHash: 'secret-hash-should-not-leak',
+  role: 'tester' as const,
+  invitedBy: 'admin@example.com',
+  revoked: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+function injectUser(req: Request, _res: Response, next: NextFunction) {
+  req.user = mockUser;
+  next();
+}
+
+function makeRequest(
+  server: http.Server,
+  path: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path, method: 'GET' },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(body) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: body } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('users routes', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('GET /api/users/me returns user info without tokenHash', async () => {
+    const app = express();
+    app.use(injectUser);
+    app.use('/api/users', usersRouter());
+    server = app.listen(0);
+
+    const res = await makeRequest(server, '/api/users/me');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.email).toBe('tester@example.com');
+    expect(data.name).toBe('Tester');
+    expect(data.role).toBe('tester');
+    expect(data.id).toBe('u1');
+    // Security: tokenHash must NOT be exposed
+    expect(data.tokenHash).toBeUndefined();
+    expect(data.invitedBy).toBeUndefined();
+    expect(data.revoked).toBeUndefined();
+  });
+});

--- a/tsconfig.dashboard.json
+++ b/tsconfig.dashboard.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/dashboard"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/widget"]
+  "exclude": ["node_modules", "dist", "src/widget", "src/dashboard"]
 }


### PR DESCRIPTION
## Summary
- Wire all adapters into `serve` command via `initAdapters()` — storage, auth, and issue adapters now available to all routes
- Add `requireAuth` Express middleware that validates session cookies and sets `req.user`
- Add 8 API route modules: auth (login/logout), rounds (CRUD), results (submit/list/delete), config, issues (create QA failure/check open), commit (cached SHA), users (/me), and dashboard (SPA static serving)
- Scaffold React SPA with Vite + Tailwind: login page, auth context, layout with nav, API client, placeholder Testing/History pages
- Identity (email/name) sourced from session on round creation and result submission — prevents spoofing
- `/api/users/me` projects to safe fields only (no `tokenHash` exposure)

closes #33
closes #38

## Test plan
- [x] `pnpm build` — compiles server + widget + dashboard (334 tests pass)
- [x] `pnpm test` — 21 new tests covering auth middleware, all route modules, identity enforcement, tokenHash exclusion
- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean (both server and dashboard tsconfigs)
- [ ] Smoke test: `pnpm cli serve`, navigate to `http://localhost:4747/`, verify SPA loads
- [ ] Smoke test: login with invite token, verify session cookie set
- [ ] Smoke test: create round via API, verify identity from session

🤖 Generated with [Claude Code](https://claude.com/claude-code)