### PR TITLE
chore: rewrite test cases for UI flows (#72)

### DIFF
--- a/punchlist.config.json
+++ b/punchlist.config.json
@@ -18,7 +18,11 @@
       "http://localhost:4747",
       "http://localhost:5173"
     ],
-    "categories": ["bug", "ux", "feature-request"]
+    "categories": [
+      "bug",
+      "ux",
+      "feature-request"
+    ]
   },
   "aiTool": "claude-code",
   "categories": [
@@ -205,7 +209,7 @@
     },
     {
       "id": "rounds-003",
-      "title": "Edit round name inline",
+      "title": "Edit round name via page header",
       "category": "rounds",
       "priority": "medium",
       "instructions": "With an active round, click the round name in the page header. Change it to a new name and press Enter.",
@@ -229,11 +233,11 @@
     },
     {
       "id": "rounds-006",
-      "title": "Edit round name inline",
+      "title": "Edit round name with keyboard shortcuts",
       "category": "rounds",
       "priority": "medium",
-      "instructions": "Click the round name header text on the Testing page. Change the text and press Enter.",
-      "expectedResult": "Name is saved. Pressing Escape reverts to the original name. Blur also saves."
+      "instructions": "Click the round name header text on the Testing page. Change the text, then test: press Enter to save, press Escape to revert, or click away (blur) to save.",
+      "expectedResult": "Enter saves the new name. Escape reverts to the original name without saving. Clicking away (blur) saves the name."
     },
     {
       "id": "rounds-007",


### PR DESCRIPTION
## Summary
- Rewrote `rounds-001` through `rounds-005` test case instructions to reference UI elements (buttons, dropdowns, inline editing) instead of curl/API commands.
- Rewrote `results-001` through `results-005` to reference TestCard buttons, FailureDialog, undo, and progress bar.
- Added 7 new test cases:
  - `dash-006` Tester name on completed cards (#70)
  - `dash-007` Issue link on TestCard after failure (#69)
  - `dash-008` Admin-only Users page (#67)
  - `dash-009` Invite user via Users page (#67)
  - `dash-010` Revoke user via Users page (#67)
  - `rounds-006` Edit round name inline (#68)
  - `rounds-007` Edit round description (#68)
- Left unchanged: auth, widget, api, and cli test cases (already UI-focused or CLI-specific).

closes #72

## Test plan
- [ ] Read through updated test cases — instructions reference UI elements, not curl commands
- [ ] Verify JSON is valid and passes config validation
- [ ] Run `pnpm build` — no errors
- [ ] Run `pnpm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)