### PR TITLE
fix: auto-login from invite URL query parameter (#83)

### DIFF
--- a/src/dashboard/components/LoginPage.tsx
+++ b/src/dashboard/components/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../hooks/useAuth';
 
 export function LoginPage() {
@@ -6,6 +6,27 @@ export function LoginPage() {
   const [token, setToken] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const autoLoginAttempted = useRef(false);
+
+  // Auto-login from invite URL query parameter
+  useEffect(() => {
+    if (autoLoginAttempted.current) return;
+    const params = new URLSearchParams(window.location.search);
+    const urlToken = params.get('token');
+    if (!urlToken) return;
+    autoLoginAttempted.current = true;
+    setLoading(true);
+    login(urlToken)
+      .then(() => {
+        // Clear token from URL without reload
+        window.history.replaceState({}, '', '/');
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Login failed');
+        setToken(urlToken);
+      })
+      .finally(() => setLoading(false));
+  }, [login]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -14,6 +35,7 @@ export function LoginPage() {
 
     try {
       await login(token);
+      window.history.replaceState({}, '', '/');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');
     } finally {


### PR DESCRIPTION
## Summary
- `LoginPage` now reads `?token=` from the URL and auto-logs in on mount
- On success, clears the token from the URL via `replaceState`
- On failure, shows the error and pre-fills the token input for manual retry

closes #83

## Test plan
- [ ] Visit `/join?token=<valid-token>` — auto-logs in, redirects to dashboard
- [ ] Visit `/join?token=bad-token` — shows error, token pre-filled for retry
- [ ] Visit `/` with no token — normal login form, no auto-login attempt
- [ ] `pnpm build && pnpm test && pnpm lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)