### PR TITLE
feat: add token regeneration for existing users (#83)

### DIFF
--- a/src/adapters/auth/token.ts
+++ b/src/adapters/auth/token.ts
@@ -92,6 +92,25 @@ export class TokenAuthAdapter implements AuthAdapter {
     return { user, token, inviteUrl };
   }
 
+  async regenerateToken(
+    email: string,
+    options?: { baseUrl?: string },
+  ): Promise<InviteResult> {
+    const user = await this.storage.getUserByEmail(email);
+    if (!user) throw new Error(`User not found: ${email}`);
+
+    const token = this.generateToken(email);
+    const tokenHash = this.hashToken(token);
+    await this.storage.updateUserTokenHash(email, tokenHash);
+
+    const base = options?.baseUrl ?? this.baseUrl;
+    const inviteUrl = `${base}/join?token=${encodeURIComponent(token)}`;
+
+    // Refetch user with updated hash
+    const updated = await this.storage.getUserByEmail(email);
+    return { user: updated!, token, inviteUrl };
+  }
+
   async revokeAccess(email: string): Promise<void> {
     await this.storage.revokeUser(email);
   }

--- a/src/adapters/auth/types.ts
+++ b/src/adapters/auth/types.ts
@@ -24,6 +24,7 @@ export interface AuthAdapter {
     options?: { role?: string; baseUrl?: string },
   ): Promise<InviteResult>;
   revokeAccess(email: string): Promise<void>;
+  regenerateToken(email: string, options?: { baseUrl?: string }): Promise<InviteResult>;
   listUsers(): Promise<User[]>;
 
   // Login (validates token hash against stored user, creates session)

--- a/src/adapters/storage/sqlite-adapter.ts
+++ b/src/adapters/storage/sqlite-adapter.ts
@@ -338,6 +338,10 @@ export class SqliteAdapter implements StorageAdapter {
     this.getDb().prepare('UPDATE users SET revoked = 1 WHERE email = ?').run(email);
   }
 
+  async updateUserTokenHash(email: string, newTokenHash: string): Promise<void> {
+    this.getDb().prepare('UPDATE users SET token_hash = ? WHERE email = ?').run(newTokenHash, email);
+  }
+
   // --- Config ---
 
   async getConfig(key: string): Promise<string | null> {

--- a/src/adapters/storage/types.ts
+++ b/src/adapters/storage/types.ts
@@ -64,6 +64,9 @@ export interface StorageAdapter {
   /** Revoke a user's access */
   revokeUser(email: string): Promise<void>;
 
+  /** Update a user's token hash (for token regeneration) */
+  updateUserTokenHash(email: string, newTokenHash: string): Promise<void>;
+
   // --- Config (key-value) ---
 
   /** Get a config value by key, or null if not set */

--- a/src/dashboard/api/client.ts
+++ b/src/dashboard/api/client.ts
@@ -86,6 +86,16 @@ export function revokeUser(email: string) {
   });
 }
 
+export function regenerateToken(email: string) {
+  return request<{
+    success: boolean;
+    data: { user: Record<string, unknown>; inviteUrl: string };
+  }>('/users/regenerate', {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  });
+}
+
 // Config
 export function getConfig() {
   return request<{

--- a/src/dashboard/pages/UsersPage.tsx
+++ b/src/dashboard/pages/UsersPage.tsx
@@ -24,6 +24,10 @@ export function UsersPage() {
   const [inviting, setInviting] = useState(false);
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
 
+  // Regenerate
+  const [shownInviteUrl, setShownInviteUrl] = useState<string | null>(null);
+  const [regenerating, setRegenerating] = useState<string | null>(null);
+
   // Revoke
   const [revokeTarget, setRevokeTarget] = useState<string | null>(null);
   const [revoking, setRevoking] = useState(false);
@@ -56,6 +60,7 @@ export function UsersPage() {
     e.preventDefault();
     setInviting(true);
     setInviteUrl(null);
+    setShownInviteUrl(null);
     setError(null);
     try {
       const res = await api.inviteUser({ email, name, role });
@@ -68,6 +73,20 @@ export function UsersPage() {
       setError(err instanceof Error ? err.message : 'Failed to invite user');
     } finally {
       setInviting(false);
+    }
+  }
+
+  async function handleRegenerate(targetEmail: string) {
+    setRegenerating(targetEmail);
+    setError(null);
+    try {
+      const res = await api.regenerateToken(targetEmail);
+      setShownInviteUrl(res.data.inviteUrl);
+      setInviteUrl(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to regenerate token');
+    } finally {
+      setRegenerating(null);
     }
   }
 
@@ -143,13 +162,26 @@ export function UsersPage() {
             {inviting ? 'Inviting...' : 'Invite'}
           </button>
         </form>
-        {inviteUrl && (
-          <div className="mt-3 bg-green-50 border border-green-200 rounded-md px-3 py-2">
-            <p className="text-xs text-green-700 mb-1">Invite created! Share this URL:</p>
-            <code className="text-xs text-green-900 break-all select-all">{inviteUrl}</code>
-          </div>
-        )}
       </div>
+
+      {(inviteUrl || shownInviteUrl) && (
+        <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-green-800">Invite URL</p>
+              <code className="text-xs text-green-900 break-all select-all">{inviteUrl || shownInviteUrl}</code>
+            </div>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText((inviteUrl || shownInviteUrl)!);
+              }}
+              className="shrink-0 ml-4 px-3 py-1.5 text-xs bg-green-100 text-green-800 hover:bg-green-200 rounded border border-green-300"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* User Table */}
       {loading ? (
@@ -190,13 +222,24 @@ export function UsersPage() {
                     {new Date(u.createdAt).toLocaleDateString()}
                   </td>
                   <td className="px-4 py-2 text-right">
-                    {!u.revoked && u.email !== user?.email && (
-                      <button
-                        onClick={() => setRevokeTarget(u.email)}
-                        className="text-xs text-red-600 hover:text-red-800"
-                      >
-                        Revoke
-                      </button>
+                    {!u.revoked && (
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          onClick={() => handleRegenerate(u.email)}
+                          disabled={regenerating === u.email}
+                          className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                        >
+                          {regenerating === u.email ? 'Regenerating...' : 'Regenerate'}
+                        </button>
+                        {u.email !== user?.email && (
+                          <button
+                            onClick={() => setRevokeTarget(u.email)}
+                            className="text-xs text-red-600 hover:text-red-800"
+                          >
+                            Revoke
+                          </button>
+                        )}
+                      </div>
                     )}
                   </td>
                 </tr>

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -80,6 +80,7 @@ function createNoopAuthAdapter(): AuthAdapter {
     validateToken: () => fail('Auth not configured'),
     createInvite: () => asyncFail('Auth not configured'),
     revokeAccess: () => asyncFail('Auth not configured'),
+    regenerateToken: () => asyncFail('Auth not configured'),
     listUsers: () => asyncFail('Auth not configured'),
     loginWithToken: () => asyncFail('Auth not configured'),
     createSession: () => asyncFail('Auth not configured'),

--- a/src/server/routes/users-api.ts
+++ b/src/server/routes/users-api.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import type { AuthAdapter } from '../../adapters/auth/types.js';
 import { requireAdmin } from '../middleware/require-admin.js';
-import { inviteUserRequestSchema, revokeUserRequestSchema } from '../../shared/schemas.js';
+import { inviteUserRequestSchema, revokeUserRequestSchema, regenerateTokenRequestSchema } from '../../shared/schemas.js';
 
 export function usersRouter(authAdapter?: AuthAdapter): Router {
   const router = Router();
@@ -46,6 +46,20 @@ export function usersRouter(authAdapter?: AuthAdapter): Router {
         const body = revokeUserRequestSchema.parse(req.body);
         await authAdapter.revokeAccess(body.email);
         res.json({ success: true });
+      } catch (err) {
+        next(err);
+      }
+    });
+
+    router.post('/regenerate', requireAdmin, async (req, res, next) => {
+      try {
+        const body = regenerateTokenRequestSchema.parse(req.body);
+        const result = await authAdapter.regenerateToken(body.email);
+        const { tokenHash: _hash, ...safeUser } = result.user;
+        res.json({
+          success: true,
+          data: { user: safeUser, inviteUrl: result.inviteUrl },
+        });
       } catch (err) {
         next(err);
       }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -167,6 +167,10 @@ export const revokeUserRequestSchema = z.object({
   email: z.string().email(),
 });
 
+export const regenerateTokenRequestSchema = z.object({
+  email: z.string().email(),
+});
+
 export const updateResultIssueSchema = z.object({
   issueUrl: z.string().url(),
   issueNumber: z.number().int().positive(),
@@ -353,6 +357,7 @@ export type SubmitResultInput = z.infer<typeof submitResultInputSchema>;
 export type CreateUserInput = z.infer<typeof createUserInputSchema>;
 export type InviteUserRequest = z.infer<typeof inviteUserRequestSchema>;
 export type RevokeUserRequest = z.infer<typeof revokeUserRequestSchema>;
+export type RegenerateTokenRequest = z.infer<typeof regenerateTokenRequestSchema>;
 export type UpdateResultIssue = z.infer<typeof updateResultIssueSchema>;
 export type Session = z.infer<typeof sessionSchema>;
 export type OpenIssue = z.infer<typeof openIssueSchema>;

--- a/tests/unit/server/results-route.test.ts
+++ b/tests/unit/server/results-route.test.ts
@@ -51,6 +51,7 @@ function createMockStorage(overrides: Partial<StorageAdapter> = {}): StorageAdap
     getUserByEmail: vi.fn(),
     getUserByTokenHash: vi.fn(),
     revokeUser: vi.fn(),
+    updateUserTokenHash: vi.fn(),
     getConfig: vi.fn(),
     setConfig: vi.fn(),
     createSession: vi.fn(),

--- a/tests/unit/server/rounds-route.test.ts
+++ b/tests/unit/server/rounds-route.test.ts
@@ -46,6 +46,7 @@ function createMockStorage(overrides: Partial<StorageAdapter> = {}): StorageAdap
     getUserByEmail: vi.fn(),
     getUserByTokenHash: vi.fn(),
     revokeUser: vi.fn(),
+    updateUserTokenHash: vi.fn(),
     getConfig: vi.fn(),
     setConfig: vi.fn(),
     createSession: vi.fn(),

--- a/tests/unit/server/users-route.test.ts
+++ b/tests/unit/server/users-route.test.ts
@@ -34,6 +34,7 @@ function createMockAuthAdapter(overrides: Partial<AuthAdapter> = {}): AuthAdapte
     validateToken: vi.fn(),
     createInvite: vi.fn(),
     revokeAccess: vi.fn(),
+    regenerateToken: vi.fn(),
     listUsers: vi.fn().mockResolvedValue([mockAdmin, mockTester]),
     loginWithToken: vi.fn(),
     createSession: vi.fn(),
@@ -209,6 +210,36 @@ describe('users routes', () => {
 
     const res = await makeRequest(server, 'POST', '/api/users/revoke', {
       email: 'admin@example.com',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('POST /api/users/regenerate returns new invite URL for admin', async () => {
+    const auth = createMockAuthAdapter({
+      regenerateToken: vi.fn().mockResolvedValue({
+        user: { ...mockTester },
+        token: 'new-tok',
+        inviteUrl: 'http://localhost:4747/join?token=new-tok',
+      }),
+    });
+    createServer(mockAdmin, auth);
+
+    const res = await makeRequest(server, 'POST', '/api/users/regenerate', {
+      email: 'tester@example.com',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.inviteUrl).toBe('http://localhost:4747/join?token=new-tok');
+    expect((data.user as Record<string, unknown>).tokenHash).toBeUndefined();
+  });
+
+  it('POST /api/users/regenerate returns 403 for tester', async () => {
+    const auth = createMockAuthAdapter();
+    createServer(mockTester, auth);
+
+    const res = await makeRequest(server, 'POST', '/api/users/regenerate', {
+      email: 'someone@example.com',
     });
     expect(res.status).toBe(403);
   });


### PR DESCRIPTION
## Summary
- New `POST /api/users/regenerate` admin-only endpoint that generates a fresh invite token for an existing user
- "Regenerate" button on Users page per active user — shows copyable invite URL
- Added `updateUserTokenHash` to StorageAdapter + SQLite implementation
- Added `regenerateToken` to AuthAdapter + TokenAuthAdapter implementation
- Shared invite URL banner with "Copy" button (used by both invite and regenerate)

closes #83

## Test plan
- [ ] As admin: click Regenerate on a user → new invite URL appears with Copy button
- [ ] Copy the URL, open in incognito → auto-login works
- [ ] Old token no longer works after regeneration
- [ ] `pnpm build && pnpm test && pnpm lint` all pass (433 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)