### PR TITLE
feat: add self-service access request flow with admin approval (#83)

### DIFF
--- a/src/adapters/storage/migrations.ts
+++ b/src/adapters/storage/migrations.ts
@@ -76,6 +76,23 @@ export const migrations: Migration[] = [
       CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);
     `,
   },
+  {
+    version: 3,
+    description: 'Create access_requests table',
+    up: `
+      CREATE TABLE IF NOT EXISTS access_requests (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        name TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        message TEXT,
+        reviewed_by TEXT,
+        reviewed_at TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_access_requests_status ON access_requests(status);
+    `,
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/adapters/storage/sqlite-adapter.ts
+++ b/src/adapters/storage/sqlite-adapter.ts
@@ -4,16 +4,25 @@ import { dirname } from 'node:path';
 import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import type { StorageAdapter } from './types.js';
 import { runMigrations } from './migrations.js';
-import { roundSchema, resultSchema, userSchema, sessionSchema } from '../../shared/schemas.js';
+import {
+  roundSchema,
+  resultSchema,
+  userSchema,
+  sessionSchema,
+  accessRequestSchema,
+} from '../../shared/schemas.js';
 import type {
   Round,
   Result,
   User,
   Session,
+  AccessRequest,
+  AccessRequestStatus,
   CreateRoundInput,
   UpdateRoundInput,
   SubmitResultInput,
   CreateUserInput,
+  CreateAccessRequestInput,
 } from '../../shared/types.js';
 
 interface SqliteAdapterOptions {
@@ -66,6 +75,17 @@ interface UserRow {
   created_at: string;
 }
 
+interface AccessRequestRow {
+  id: string;
+  email: string;
+  name: string;
+  status: string;
+  message: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+}
+
 function rowToRound(row: RoundRow): Round {
   return roundSchema.parse({
     id: row.id,
@@ -115,6 +135,19 @@ function rowToUser(row: UserRow): User {
     role: row.role,
     invitedBy: row.invited_by,
     revoked: row.revoked === 1,
+    createdAt: row.created_at,
+  });
+}
+
+function rowToAccessRequest(row: AccessRequestRow): AccessRequest {
+  return accessRequestSchema.parse({
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    status: row.status as AccessRequestStatus,
+    message: row.message,
+    reviewedBy: row.reviewed_by,
+    reviewedAt: row.reviewed_at,
     createdAt: row.created_at,
   });
 }
@@ -456,6 +489,46 @@ export class SqliteAdapter implements StorageAdapter {
     }, intervalMs);
     timer.unref();
     return () => clearInterval(timer);
+  }
+
+  // --- Access Requests ---
+
+  async createAccessRequest(input: CreateAccessRequestInput): Promise<AccessRequest> {
+    const db = this.getDb();
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO access_requests (id, email, name, status, message, created_at)
+       VALUES (?, ?, ?, 'pending', ?, ?)`,
+    ).run(id, input.email, input.name, input.message ?? null, now);
+    const row = db.prepare('SELECT * FROM access_requests WHERE id = ?').get(id) as AccessRequestRow;
+    return rowToAccessRequest(row);
+  }
+
+  async listAccessRequests(status?: string): Promise<AccessRequest[]> {
+    const db = this.getDb();
+    const rows = status
+      ? (db.prepare('SELECT * FROM access_requests WHERE status = ? ORDER BY created_at DESC').all(status) as AccessRequestRow[])
+      : (db.prepare('SELECT * FROM access_requests ORDER BY created_at DESC').all() as AccessRequestRow[]);
+    return rows.map(rowToAccessRequest);
+  }
+
+  async getAccessRequest(id: string): Promise<AccessRequest | null> {
+    const row = this.getDb().prepare('SELECT * FROM access_requests WHERE id = ?').get(id) as AccessRequestRow | undefined;
+    return row ? rowToAccessRequest(row) : null;
+  }
+
+  async getAccessRequestByEmail(email: string): Promise<AccessRequest | null> {
+    const row = this.getDb().prepare('SELECT * FROM access_requests WHERE email = ?').get(email) as AccessRequestRow | undefined;
+    return row ? rowToAccessRequest(row) : null;
+  }
+
+  async updateAccessRequestStatus(id: string, status: string, reviewedBy: string): Promise<AccessRequest> {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+    db.prepare('UPDATE access_requests SET status = ?, reviewed_by = ?, reviewed_at = ? WHERE id = ?').run(status, reviewedBy, now, id);
+    const row = db.prepare('SELECT * FROM access_requests WHERE id = ?').get(id) as AccessRequestRow;
+    return rowToAccessRequest(row);
   }
 
   // --- Internal ---

--- a/src/adapters/storage/types.ts
+++ b/src/adapters/storage/types.ts
@@ -3,10 +3,12 @@ import type {
   Result,
   User,
   Session,
+  AccessRequest,
   CreateRoundInput,
   UpdateRoundInput,
   SubmitResultInput,
   CreateUserInput,
+  CreateAccessRequestInput,
 } from '../../shared/types.js';
 
 export interface StorageAdapter {
@@ -88,4 +90,21 @@ export interface StorageAdapter {
 
   /** Delete all expired sessions */
   deleteExpiredSessions(): Promise<void>;
+
+  // --- Access Requests ---
+
+  /** Create an access request */
+  createAccessRequest(input: CreateAccessRequestInput): Promise<AccessRequest>;
+
+  /** List access requests, optionally filtered by status */
+  listAccessRequests(status?: string): Promise<AccessRequest[]>;
+
+  /** Get access request by ID */
+  getAccessRequest(id: string): Promise<AccessRequest | null>;
+
+  /** Get access request by email */
+  getAccessRequestByEmail(email: string): Promise<AccessRequest | null>;
+
+  /** Update access request status */
+  updateAccessRequestStatus(id: string, status: string, reviewedBy: string): Promise<AccessRequest>;
 }

--- a/src/dashboard/api/client.ts
+++ b/src/dashboard/api/client.ts
@@ -181,6 +181,35 @@ export function getOpenIssue(testId: string) {
   }>(`/issues/open/${testId}`);
 }
 
+// Access Requests
+export function requestAccess(input: { email: string; name: string; message?: string }) {
+  return request<{ success: boolean; data: Record<string, unknown> }>('/access-requests', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
+export function listAccessRequests(status?: string) {
+  const qs = status ? `?status=${status}` : '';
+  return request<{ success: boolean; data: Array<Record<string, unknown>> }>(
+    `/access-requests${qs}`,
+  );
+}
+
+export function approveAccessRequest(id: string) {
+  return request<{
+    success: boolean;
+    data: { request: Record<string, unknown>; user: Record<string, unknown>; inviteUrl: string };
+  }>(`/access-requests/${id}/approve`, { method: 'POST' });
+}
+
+export function rejectAccessRequest(id: string) {
+  return request<{ success: boolean; data: Record<string, unknown> }>(
+    `/access-requests/${id}/reject`,
+    { method: 'POST' },
+  );
+}
+
 // Commit
 export function getCommitSha() {
   return request<{ success: boolean; data: { sha: string } }>('/commit');

--- a/src/dashboard/components/LoginPage.tsx
+++ b/src/dashboard/components/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../hooks/useAuth';
+import * as api from '../api/client';
 
 export function LoginPage() {
   const { login } = useAuth();
@@ -7,6 +8,15 @@ export function LoginPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const autoLoginAttempted = useRef(false);
+
+  // Access request state
+  const [mode, setMode] = useState<'login' | 'request'>('login');
+  const [reqEmail, setReqEmail] = useState('');
+  const [reqName, setReqName] = useState('');
+  const [reqMessage, setReqMessage] = useState('');
+  const [requesting, setRequesting] = useState(false);
+  const [requestSuccess, setRequestSuccess] = useState(false);
+  const [requestError, setRequestError] = useState('');
 
   // Auto-login from invite URL query parameter
   useEffect(() => {
@@ -43,32 +53,124 @@ export function LoginPage() {
     }
   }
 
+  async function handleRequestAccess(e: React.FormEvent) {
+    e.preventDefault();
+    setRequestError('');
+    setRequesting(true);
+    try {
+      await api.requestAccess({ email: reqEmail, name: reqName, message: reqMessage || undefined });
+      setRequestSuccess(true);
+    } catch (err) {
+      setRequestError(err instanceof Error ? err.message : 'Request failed');
+    } finally {
+      setRequesting(false);
+    }
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 w-full max-w-md">
         <h1 className="text-xl font-semibold text-gray-900 mb-6">Punchlist QA</h1>
-        <form onSubmit={handleSubmit}>
-          <label htmlFor="token" className="block text-sm font-medium text-gray-700 mb-2">
-            Invite Token
-          </label>
-          <input
-            id="token"
-            type="password"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="Paste your invite token"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            disabled={loading}
-          />
-          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
-          <button
-            type="submit"
-            disabled={loading || !token.trim()}
-            className="mt-4 w-full bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {loading ? 'Signing in...' : 'Sign In'}
-          </button>
-        </form>
+        {mode === 'login' && (
+          <form onSubmit={handleSubmit}>
+            <label htmlFor="token" className="block text-sm font-medium text-gray-700 mb-2">
+              Invite Token
+            </label>
+            <input
+              id="token"
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="Paste your invite token"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              disabled={loading}
+            />
+            {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading || !token.trim()}
+              className="mt-4 w-full bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Signing in...' : 'Sign In'}
+            </button>
+          </form>
+        )}
+        <div className="mt-6 pt-4 border-t border-gray-200">
+          {mode === 'login' ? (
+            <button
+              type="button"
+              onClick={() => setMode('request')}
+              className="text-sm text-blue-600 hover:text-blue-800"
+            >
+              Need access? Request an invite
+            </button>
+          ) : requestSuccess ? (
+            <div className="text-center">
+              <p className="text-sm text-green-700 font-medium">Request submitted!</p>
+              <p className="text-xs text-gray-500 mt-1">
+                An admin will review your request. You will receive an invite link once approved.
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  setMode('login');
+                  setRequestSuccess(false);
+                }}
+                className="mt-3 text-sm text-blue-600 hover:text-blue-800"
+              >
+                Back to login
+              </button>
+            </div>
+          ) : (
+            <>
+              <p className="text-sm font-medium text-gray-700 mb-3">Request Access</p>
+              <form onSubmit={handleRequestAccess} className="space-y-3">
+                <input
+                  type="email"
+                  value={reqEmail}
+                  onChange={(e) => setReqEmail(e.target.value)}
+                  placeholder="Email address"
+                  required
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  disabled={requesting}
+                />
+                <input
+                  type="text"
+                  value={reqName}
+                  onChange={(e) => setReqName(e.target.value)}
+                  placeholder="Your name"
+                  required
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  disabled={requesting}
+                />
+                <textarea
+                  value={reqMessage}
+                  onChange={(e) => setReqMessage(e.target.value)}
+                  placeholder="Why do you need access? (optional)"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent h-20 resize-none"
+                  disabled={requesting}
+                />
+                {requestError && <p className="text-sm text-red-600">{requestError}</p>}
+                <div className="flex items-center justify-between">
+                  <button
+                    type="button"
+                    onClick={() => setMode('login')}
+                    className="text-sm text-gray-500 hover:text-gray-700"
+                  >
+                    Back to login
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={requesting}
+                    className="bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    {requesting ? 'Submitting...' : 'Request Access'}
+                  </button>
+                </div>
+              </form>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/dashboard/pages/UsersPage.tsx
+++ b/src/dashboard/pages/UsersPage.tsx
@@ -11,6 +11,17 @@ interface UserRecord {
   createdAt: string;
 }
 
+interface AccessRequestRecord {
+  id: string;
+  email: string;
+  name: string;
+  status: string;
+  message: string | null;
+  reviewedBy: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+}
+
 export function UsersPage() {
   const { user } = useAuth();
   const [users, setUsers] = useState<UserRecord[]>([]);
@@ -28,21 +39,29 @@ export function UsersPage() {
   const [revokeTarget, setRevokeTarget] = useState<string | null>(null);
   const [revoking, setRevoking] = useState(false);
 
-  const loadUsers = useCallback(async () => {
+  // Access requests
+  const [accessRequests, setAccessRequests] = useState<AccessRequestRecord[]>([]);
+  const [approving, setApproving] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
     try {
-      const res = await api.listUsers();
-      setUsers(res.data as unknown as UserRecord[]);
+      const [usersRes, requestsRes] = await Promise.all([
+        api.listUsers(),
+        api.listAccessRequests(),
+      ]);
+      setUsers(usersRes.data as unknown as UserRecord[]);
+      setAccessRequests(requestsRes.data as unknown as AccessRequestRecord[]);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load users');
+      setError(err instanceof Error ? err.message : 'Failed to load data');
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    if (user?.role === 'admin') loadUsers();
+    if (user?.role === 'admin') loadData();
     else setLoading(false);
-  }, [user?.role, loadUsers]);
+  }, [user?.role, loadData]);
 
   if (user?.role !== 'admin') {
     return (
@@ -63,7 +82,7 @@ export function UsersPage() {
       setEmail('');
       setName('');
       setRole('tester');
-      await loadUsers();
+      await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to invite user');
     } finally {
@@ -77,11 +96,38 @@ export function UsersPage() {
     try {
       await api.revokeUser(targetEmail);
       setRevokeTarget(null);
-      await loadUsers();
+      await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to revoke user');
     } finally {
       setRevoking(false);
+    }
+  }
+
+  async function handleApprove(requestId: string) {
+    setApproving(requestId);
+    setError(null);
+    try {
+      const res = await api.approveAccessRequest(requestId);
+      setInviteUrl(res.data.inviteUrl);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to approve request');
+    } finally {
+      setApproving(null);
+    }
+  }
+
+  async function handleReject(requestId: string) {
+    setApproving(requestId);
+    setError(null);
+    try {
+      await api.rejectAccessRequest(requestId);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reject request');
+    } finally {
+      setApproving(null);
     }
   }
 
@@ -203,6 +249,49 @@ export function UsersPage() {
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+
+      {/* Access Requests */}
+      {accessRequests.filter((r) => r.status === 'pending').length > 0 && (
+        <div className="bg-white border border-amber-200 rounded-lg overflow-hidden">
+          <div className="px-4 py-3 bg-amber-50 border-b border-amber-200">
+            <h2 className="text-sm font-medium text-amber-800">
+              Pending Access Requests ({accessRequests.filter((r) => r.status === 'pending').length})
+            </h2>
+          </div>
+          <div className="divide-y divide-gray-100">
+            {accessRequests
+              .filter((r) => r.status === 'pending')
+              .map((r) => (
+                <div key={r.id} className="px-4 py-3 flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">{r.name}</p>
+                    <p className="text-xs text-gray-500">{r.email}</p>
+                    {r.message && <p className="text-xs text-gray-400 mt-1">{r.message}</p>}
+                    <p className="text-xs text-gray-400">
+                      Requested {new Date(r.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => handleApprove(r.id)}
+                      disabled={approving === r.id}
+                      className="text-xs px-3 py-1.5 bg-green-50 text-green-700 hover:bg-green-100 rounded border border-green-200 disabled:opacity-50"
+                    >
+                      {approving === r.id ? 'Approving...' : 'Approve'}
+                    </button>
+                    <button
+                      onClick={() => handleReject(r.id)}
+                      disabled={approving === r.id}
+                      className="text-xs px-3 py-1.5 bg-red-50 text-red-700 hover:bg-red-100 rounded border border-red-200 disabled:opacity-50"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                </div>
+              ))}
+          </div>
         </div>
       )}
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -12,6 +12,10 @@ import { configRouter } from './routes/config.js';
 import { issuesRouter } from './routes/issues-api.js';
 import { commitRouter } from './routes/commit.js';
 import { usersRouter } from './routes/users-api.js';
+import {
+  publicAccessRequestRouter,
+  adminAccessRequestRouter,
+} from './routes/access-requests.js';
 import { dashboardRouter } from './routes/dashboard.js';
 import type { IssueAdapter } from '../adapters/issues/types.js';
 import type { StorageAdapter } from '../adapters/storage/types.js';
@@ -47,6 +51,9 @@ export function createApp(deps: AppDependencies): Express {
   // Public routes (no auth required)
   app.use('/api/support', supportRouter(deps.issueAdapter));
   app.use('/api/auth', authRouter(deps.authAdapter ?? createNoopAuthAdapter()));
+  if (deps.storageAdapter) {
+    app.use('/api/access-requests', publicAccessRequestRouter(deps.storageAdapter));
+  }
 
   // Protected routes (require valid session)
   if (deps.storageAdapter && deps.authAdapter && deps.config) {
@@ -58,6 +65,7 @@ export function createApp(deps: AppDependencies): Express {
     app.use('/api/issues', auth, issuesRouter(deps.issueAdapter));
     app.use('/api/commit', auth, commitRouter());
     app.use('/api/users', auth, usersRouter(deps.authAdapter));
+    app.use('/api/access-requests', auth, adminAccessRequestRouter(deps.storageAdapter, deps.authAdapter));
   }
 
   // Static file serving

--- a/src/server/routes/access-requests.ts
+++ b/src/server/routes/access-requests.ts
@@ -1,0 +1,140 @@
+import { Router } from 'express';
+import type { StorageAdapter } from '../../adapters/storage/types.js';
+import type { AuthAdapter } from '../../adapters/auth/types.js';
+import { createAccessRequestInputSchema } from '../../shared/schemas.js';
+import { requireAdmin } from '../middleware/require-admin.js';
+
+/**
+ * Public router: POST / to submit an access request (no auth required).
+ */
+export function publicAccessRequestRouter(storageAdapter: StorageAdapter): Router {
+  const router = Router();
+
+  router.post('/', async (req, res, next) => {
+    try {
+      const body = createAccessRequestInputSchema.parse(req.body);
+
+      // Check if user already exists
+      const existingUser = await storageAdapter.getUserByEmail(body.email);
+      if (existingUser) {
+        res.status(409).json({ success: false, error: 'An account with this email already exists' });
+        return;
+      }
+
+      // Check for existing pending request
+      const existingRequest = await storageAdapter.getAccessRequestByEmail(body.email);
+      if (existingRequest && existingRequest.status === 'pending') {
+        res.status(409).json({ success: false, error: 'A request for this email is already pending' });
+        return;
+      }
+
+      // If previously rejected/approved, delete old record first (UNIQUE constraint on email)
+      if (existingRequest) {
+        await storageAdapter.updateAccessRequestStatus(existingRequest.id, 'rejected', 'system');
+        // Delete the old record so we can insert fresh
+        // Since we don't have a delete method, we update + rely on UNIQUE constraint
+        // Actually we need to work around the UNIQUE constraint — update the existing record instead
+        const updated = await storageAdapter.updateAccessRequestStatus(
+          existingRequest.id,
+          'pending',
+          'system',
+        );
+        res.status(201).json({ success: true, data: updated });
+        return;
+      }
+
+      const request = await storageAdapter.createAccessRequest(body);
+      res.status(201).json({ success: true, data: request });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+/**
+ * Admin router: list, approve, reject access requests (requires auth + admin).
+ */
+export function adminAccessRequestRouter(
+  storageAdapter: StorageAdapter,
+  authAdapter: AuthAdapter,
+): Router {
+  const router = Router();
+
+  // List all access requests
+  router.get('/', requireAdmin, async (req, res, next) => {
+    try {
+      const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+      const requests = await storageAdapter.listAccessRequests(status);
+      res.json({ success: true, data: requests });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Approve request (creates user invite)
+  router.post('/:id/approve', requireAdmin, async (req, res, next) => {
+    try {
+      const id = req.params.id as string;
+      const request = await storageAdapter.getAccessRequest(id);
+      if (!request) {
+        res.status(404).json({ success: false, error: 'Access request not found' });
+        return;
+      }
+      if (request.status !== 'pending') {
+        res.status(400).json({ success: false, error: `Request already ${request.status}` });
+        return;
+      }
+
+      // Create the user invite
+      const inviteResult = await authAdapter.createInvite(request.email, request.name, req.user!.email);
+
+      // Mark request as approved
+      const updated = await storageAdapter.updateAccessRequestStatus(
+        request.id,
+        'approved',
+        req.user!.email,
+      );
+
+      const { tokenHash: _hash, ...safeUser } = inviteResult.user;
+      res.json({
+        success: true,
+        data: {
+          request: updated,
+          user: safeUser,
+          inviteUrl: inviteResult.inviteUrl,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Reject request
+  router.post('/:id/reject', requireAdmin, async (req, res, next) => {
+    try {
+      const id = req.params.id as string;
+      const request = await storageAdapter.getAccessRequest(id);
+      if (!request) {
+        res.status(404).json({ success: false, error: 'Access request not found' });
+        return;
+      }
+      if (request.status !== 'pending') {
+        res.status(400).json({ success: false, error: `Request already ${request.status}` });
+        return;
+      }
+
+      const updated = await storageAdapter.updateAccessRequestStatus(
+        request.id,
+        'rejected',
+        req.user!.email,
+      );
+      res.json({ success: true, data: updated });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -253,6 +253,27 @@ export const sessionSchema = z.object({
   createdAt: z.string(),
 });
 
+// --- Access Request schemas ---
+
+export const accessRequestStatusSchema = z.enum(['pending', 'approved', 'rejected']);
+
+export const accessRequestSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string(),
+  status: accessRequestStatusSchema,
+  message: z.string().nullable(),
+  reviewedBy: z.string().email().nullable(),
+  reviewedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+export const createAccessRequestInputSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+  message: z.string().max(500).optional(),
+});
+
 // --- Main config schema ---
 
 export const punchlistConfigSchema = z
@@ -361,3 +382,6 @@ export type CreateSupportTicketOpts = z.infer<typeof createSupportTicketOptsSche
 export type LabelDef = z.infer<typeof labelDefSchema>;
 export type SupportTicketRequest = z.infer<typeof supportTicketRequestSchema>;
 export type LoginRequest = z.infer<typeof loginRequestSchema>;
+export type AccessRequestStatus = z.infer<typeof accessRequestStatusSchema>;
+export type AccessRequest = z.infer<typeof accessRequestSchema>;
+export type CreateAccessRequestInput = z.infer<typeof createAccessRequestInputSchema>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,4 +34,7 @@ export type {
   LabelDef,
   SupportTicketRequest,
   LoginRequest,
+  AccessRequestStatus,
+  AccessRequest,
+  CreateAccessRequestInput,
 } from './schemas.js';

--- a/tests/unit/server/access-requests-route.test.ts
+++ b/tests/unit/server/access-requests-route.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import type { Request, Response, NextFunction } from 'express';
+import type { StorageAdapter } from '../../../src/adapters/storage/types.js';
+import type { AuthAdapter } from '../../../src/adapters/auth/types.js';
+import {
+  publicAccessRequestRouter,
+  adminAccessRequestRouter,
+} from '../../../src/server/routes/access-requests.js';
+import { errorHandler } from '../../../src/server/middleware/error-handler.js';
+
+const mockAdmin = {
+  id: 'u1',
+  email: 'admin@example.com',
+  name: 'Admin',
+  tokenHash: 'secret-hash',
+  role: 'admin' as const,
+  invitedBy: 'root@example.com',
+  revoked: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+const mockTester = {
+  id: 'u2',
+  email: 'tester@example.com',
+  name: 'Tester',
+  tokenHash: 'secret-hash-2',
+  role: 'tester' as const,
+  invitedBy: 'admin@example.com',
+  revoked: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+const mockAccessRequest = {
+  id: 'ar-1',
+  email: 'requester@example.com',
+  name: 'New User',
+  status: 'pending' as const,
+  message: 'I would like access',
+  reviewedBy: null,
+  reviewedAt: null,
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+function createMockStorage(overrides: Partial<StorageAdapter> = {}): StorageAdapter {
+  return {
+    initialize: vi.fn(),
+    close: vi.fn(),
+    createRound: vi.fn(),
+    listRounds: vi.fn(),
+    getRound: vi.fn(),
+    updateRound: vi.fn(),
+    submitResult: vi.fn(),
+    listResults: vi.fn(),
+    deleteResult: vi.fn(),
+    deleteResultsByTestIds: vi.fn(),
+    updateResultIssue: vi.fn(),
+    createUser: vi.fn(),
+    listUsers: vi.fn(),
+    getUserByEmail: vi.fn().mockResolvedValue(null),
+    getUserByTokenHash: vi.fn(),
+    revokeUser: vi.fn(),
+    getConfig: vi.fn(),
+    setConfig: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(),
+    getSessionWithUser: vi.fn(),
+    deleteSession: vi.fn(),
+    deleteExpiredSessions: vi.fn(),
+    createAccessRequest: vi.fn().mockResolvedValue(mockAccessRequest),
+    listAccessRequests: vi.fn().mockResolvedValue([mockAccessRequest]),
+    getAccessRequest: vi.fn().mockResolvedValue(mockAccessRequest),
+    getAccessRequestByEmail: vi.fn().mockResolvedValue(null),
+    updateAccessRequestStatus: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createMockAuthAdapter(overrides: Partial<AuthAdapter> = {}): AuthAdapter {
+  return {
+    generateToken: vi.fn(),
+    validateToken: vi.fn(),
+    createInvite: vi.fn().mockResolvedValue({
+      user: { ...mockTester, email: 'requester@example.com', name: 'New User' },
+      token: 'tok-123',
+      inviteUrl: 'http://localhost:4747?token=tok-123',
+    }),
+    revokeAccess: vi.fn(),
+    listUsers: vi.fn().mockResolvedValue([]),
+    loginWithToken: vi.fn(),
+    createSession: vi.fn(),
+    validateSession: vi.fn(),
+    destroySession: vi.fn(),
+    ...overrides,
+  } as AuthAdapter;
+}
+
+function injectUser(user: typeof mockAdmin) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    req.user = user;
+    next();
+  };
+}
+
+function makeRequest(
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : undefined;
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: data
+          ? { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(data)) }
+          : {},
+      },
+      (res) => {
+        let resBody = '';
+        res.on('data', (chunk) => (resBody += chunk));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: JSON.parse(resBody) });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw: resBody } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+describe('access-requests routes', () => {
+  let server: http.Server;
+  let storage: StorageAdapter;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  function createServer(user?: typeof mockAdmin, authAdapter?: AuthAdapter) {
+    storage = createMockStorage();
+    const app = express();
+    app.use(express.json());
+
+    // Public route
+    app.use('/api/access-requests', publicAccessRequestRouter(storage));
+
+    // Admin routes (with auth)
+    if (user) {
+      app.use(injectUser(user));
+      app.use(
+        '/api/access-requests',
+        adminAccessRequestRouter(storage, authAdapter ?? createMockAuthAdapter()),
+      );
+    }
+
+    app.use(errorHandler);
+    server = app.listen(0);
+    return server;
+  }
+
+  // --- Public POST ---
+
+  it('POST /api/access-requests creates a pending request', async () => {
+    createServer();
+
+    const res = await makeRequest(server, 'POST', '/api/access-requests', {
+      email: 'new@example.com',
+      name: 'New Person',
+      message: 'Please let me in',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(storage.createAccessRequest).toHaveBeenCalledWith({
+      email: 'new@example.com',
+      name: 'New Person',
+      message: 'Please let me in',
+    });
+  });
+
+  it('POST /api/access-requests returns 409 for duplicate pending request', async () => {
+    storage = createMockStorage({
+      getAccessRequestByEmail: vi.fn().mockResolvedValue(mockAccessRequest),
+    });
+    const app = express();
+    app.use(express.json());
+    app.use('/api/access-requests', publicAccessRequestRouter(storage));
+    app.use(errorHandler);
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'POST', '/api/access-requests', {
+      email: 'requester@example.com',
+      name: 'Existing',
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('A request for this email is already pending');
+  });
+
+  it('POST /api/access-requests returns 409 for existing user', async () => {
+    storage = createMockStorage({
+      getUserByEmail: vi.fn().mockResolvedValue(mockAdmin),
+    });
+    const app = express();
+    app.use(express.json());
+    app.use('/api/access-requests', publicAccessRequestRouter(storage));
+    app.use(errorHandler);
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'POST', '/api/access-requests', {
+      email: 'admin@example.com',
+      name: 'Admin',
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('An account with this email already exists');
+  });
+
+  it('POST /api/access-requests returns 400 for invalid body', async () => {
+    createServer();
+
+    const res = await makeRequest(server, 'POST', '/api/access-requests', {
+      email: 'not-an-email',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // --- Admin GET ---
+
+  it('GET /api/access-requests returns list for admin', async () => {
+    createServer(mockAdmin);
+
+    const res = await makeRequest(server, 'GET', '/api/access-requests');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('GET /api/access-requests returns 403 for tester', async () => {
+    createServer(mockTester);
+
+    const res = await makeRequest(server, 'GET', '/api/access-requests');
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Admin access required');
+  });
+
+  // --- Admin approve ---
+
+  it('POST /api/access-requests/:id/approve creates invite and marks approved', async () => {
+    const auth = createMockAuthAdapter();
+    const updatedRequest = { ...mockAccessRequest, status: 'approved', reviewedBy: 'admin@example.com' };
+    storage = createMockStorage({
+      getAccessRequest: vi.fn().mockResolvedValue(mockAccessRequest),
+      updateAccessRequestStatus: vi.fn().mockResolvedValue(updatedRequest),
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api/access-requests', publicAccessRequestRouter(storage));
+    app.use(injectUser(mockAdmin));
+    app.use('/api/access-requests', adminAccessRequestRouter(storage, auth));
+    app.use(errorHandler);
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'POST', '/api/access-requests/ar-1/approve');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.inviteUrl).toBe('http://localhost:4747?token=tok-123');
+    expect(auth.createInvite).toHaveBeenCalledWith('requester@example.com', 'New User', 'admin@example.com');
+    expect(storage.updateAccessRequestStatus).toHaveBeenCalledWith('ar-1', 'approved', 'admin@example.com');
+  });
+
+  // --- Admin reject ---
+
+  it('POST /api/access-requests/:id/reject marks rejected', async () => {
+    const rejectedRequest = { ...mockAccessRequest, status: 'rejected', reviewedBy: 'admin@example.com' };
+    storage = createMockStorage({
+      getAccessRequest: vi.fn().mockResolvedValue(mockAccessRequest),
+      updateAccessRequestStatus: vi.fn().mockResolvedValue(rejectedRequest),
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api/access-requests', publicAccessRequestRouter(storage));
+    app.use(injectUser(mockAdmin));
+    app.use('/api/access-requests', adminAccessRequestRouter(storage, createMockAuthAdapter()));
+    app.use(errorHandler);
+    server = app.listen(0);
+
+    const res = await makeRequest(server, 'POST', '/api/access-requests/ar-1/reject');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(storage.updateAccessRequestStatus).toHaveBeenCalledWith('ar-1', 'rejected', 'admin@example.com');
+  });
+});

--- a/tests/unit/server/results-route.test.ts
+++ b/tests/unit/server/results-route.test.ts
@@ -58,6 +58,11 @@ function createMockStorage(overrides: Partial<StorageAdapter> = {}): StorageAdap
     getSessionWithUser: vi.fn(),
     deleteSession: vi.fn(),
     deleteExpiredSessions: vi.fn(),
+    createAccessRequest: vi.fn(),
+    listAccessRequests: vi.fn().mockResolvedValue([]),
+    getAccessRequest: vi.fn(),
+    getAccessRequestByEmail: vi.fn(),
+    updateAccessRequestStatus: vi.fn(),
     ...overrides,
   };
 }

--- a/tests/unit/server/rounds-route.test.ts
+++ b/tests/unit/server/rounds-route.test.ts
@@ -53,6 +53,11 @@ function createMockStorage(overrides: Partial<StorageAdapter> = {}): StorageAdap
     getSessionWithUser: vi.fn(),
     deleteSession: vi.fn(),
     deleteExpiredSessions: vi.fn(),
+    createAccessRequest: vi.fn(),
+    listAccessRequests: vi.fn().mockResolvedValue([]),
+    getAccessRequest: vi.fn(),
+    getAccessRequestByEmail: vi.fn(),
+    updateAccessRequestStatus: vi.fn(),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- **Login page**: "Need access? Request an invite" link toggles to a request form (email, name, optional message)
- **Public API**: `POST /api/access-requests` — no auth required, creates a pending request. Rejects duplicates and existing users (409)
- **Admin API**: `GET /api/access-requests`, `POST /:id/approve`, `POST /:id/reject` — admin-only
- **Users page**: Pending access requests section with Approve/Reject buttons. Approve auto-creates the user invite and shows copyable URL
- New `access_requests` DB table (migration v3) with status, message, reviewer tracking
- 8 new route tests

## Flow
1. User visits login page → clicks "Need access?" → submits email/name
2. Admin sees pending request on Users page
3. Admin clicks "Approve" → user invite created → invite URL shown
4. Admin copies URL and sends via Slack/email/etc.
5. User visits invite URL → auto-logged in (from PR #84)

## Test plan
- [ ] Submit access request from login page → success message shown
- [ ] Submit duplicate → error "already pending"
- [ ] As admin: see pending requests, approve one → invite URL appears
- [ ] As admin: reject a request → it disappears
- [ ] `pnpm build && pnpm test && pnpm lint` all pass (438+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)