### PR TITLE
fix: resolve project-specific GitHub adapter for issues API

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -115,7 +115,13 @@ export function createApp(deps: AppDependencies): Express {
     const projectScope = requireProjectContext(storage);
     app.use('/api/projects/:projectId/rounds', requireAuth, projectScope, roundsRouter(storage));
     app.use('/api/projects/:projectId/rounds', requireAuth, projectScope, resultsRouter(storage));
-    app.use('/api/projects/:projectId/issues', requireAuth, projectScope, issuesRouter(deps.issueAdapter));
+    const issuesDeps = {
+      issueAdapter: deps.issueAdapter,
+      issueAdapterRegistry: deps.issueAdapterRegistry,
+      storageAdapter: storage,
+      encryptionSecret: sessionSecret,
+    };
+    app.use('/api/projects/:projectId/issues', requireAuth, projectScope, issuesRouter(issuesDeps));
     app.use(
       '/api/projects/:projectId/access-requests',
       requireAuth,
@@ -142,7 +148,7 @@ export function createApp(deps: AppDependencies): Express {
     app.use('/api/rounds', requireAuth, defaultProject, roundsRouter(storage));
     app.use('/api/rounds', requireAuth, defaultProject, resultsRouter(storage));
     app.use('/api/config', requireAuth, defaultProject, configRouter({ config: deps.config, storageAdapter: storage }));
-    app.use('/api/issues', requireAuth, defaultProject, issuesRouter(deps.issueAdapter));
+    app.use('/api/issues', requireAuth, defaultProject, issuesRouter(issuesDeps));
     app.use('/api/commit', requireAuth, commitRouter());
     app.use('/api/users', requireAuth, usersRouter(storage, sessionSecret));
     app.use(

--- a/src/server/routes/issues-api.ts
+++ b/src/server/routes/issues-api.ts
@@ -1,14 +1,38 @@
 import { Router } from 'express';
 import type { IssueAdapter } from '../../adapters/issues/types.js';
+import type { IssueAdapterRegistry } from '../../adapters/issues/registry.js';
+import type { StorageAdapter } from '../../adapters/storage/types.js';
 import { createQAFailureOptsSchema } from '../../shared/schemas.js';
 
-export function issuesRouter(issueAdapter: IssueAdapter): Router {
-  const router = Router();
+export interface IssuesRouterDeps {
+  /** Fallback adapter for CLI / single-project mode */
+  issueAdapter: IssueAdapter;
+  /** Registry for resolving per-project adapters in hosted mode */
+  issueAdapterRegistry?: IssueAdapterRegistry;
+  /** Storage adapter for token resolution */
+  storageAdapter?: StorageAdapter;
+  /** Encryption secret for decrypting per-org GitHub tokens */
+  encryptionSecret?: string;
+}
+
+export function issuesRouter(deps: IssuesRouterDeps): Router {
+  const router = Router({ mergeParams: true });
 
   router.post('/', async (req, res, next) => {
     try {
       const opts = createQAFailureOptsSchema.parse(req.body);
-      const issue = await issueAdapter.createQAFailureIssue(opts);
+
+      // Resolve project-specific adapter when project context is available
+      let adapter = deps.issueAdapter;
+      if (req.project && deps.issueAdapterRegistry && deps.storageAdapter && deps.encryptionSecret) {
+        adapter = await deps.issueAdapterRegistry.getAdapter(
+          req.project.repoSlug,
+          deps.storageAdapter,
+          deps.encryptionSecret,
+        );
+      }
+
+      const issue = await adapter.createQAFailureIssue(opts);
       res.status(201).json({ success: true, data: issue });
     } catch (err) {
       next(err);
@@ -17,7 +41,17 @@ export function issuesRouter(issueAdapter: IssueAdapter): Router {
 
   router.get('/open/:testId', async (req, res, next) => {
     try {
-      const issue = await issueAdapter.getOpenIssueForTest(req.params.testId);
+      // Resolve project-specific adapter when project context is available
+      let adapter = deps.issueAdapter;
+      if (req.project && deps.issueAdapterRegistry && deps.storageAdapter && deps.encryptionSecret) {
+        adapter = await deps.issueAdapterRegistry.getAdapter(
+          req.project.repoSlug,
+          deps.storageAdapter,
+          deps.encryptionSecret,
+        );
+      }
+
+      const issue = await adapter.getOpenIssueForTest(req.params.testId);
       res.json({ success: true, data: issue });
     } catch (err) {
       next(err);


### PR DESCRIPTION
## Summary
- The `/api/projects/:projectId/issues` endpoint was using the placeholder `GitHubIssueAdapter('placeholder/repo')` instead of resolving the correct repo from the project context
- Now uses `IssueAdapterRegistry` to get the correct adapter per project, with proper per-org token resolution
- Same fix applied to the legacy `/api/issues` route

## Test plan
- [x] All 527 tests pass
- [x] Type check passes
- [x] Lint passes
- [ ] Test filing an issue from the dashboard on sbi-bids project

🤖 Generated with [Claude Code](https://claude.com/claude-code)